### PR TITLE
add support for Anthropic, Palm, Cohere, Replicate, TogetherAI, Baseten, etc.

### DIFF
--- a/package/gentrace/providers/llms/openai.py
+++ b/package/gentrace/providers/llms/openai.py
@@ -760,8 +760,8 @@ def swap_methods(cls, attribute: str, gentrace_config: Configuration, intercept_
 def annotate_openai_module(
     gentrace_config: Configuration,
 ):
-    import openai
-
+    import openai 
+    from litellm import embedding, completion, acompletion 
     for name, cls in vars(openai.api_resources).items():
         if isinstance(cls, type):
             if name == "Completion":
@@ -780,6 +780,10 @@ def annotate_openai_module(
                 swap_methods(cls, "acreate", gentrace_config, intercept_embedding_async)
 
             setattr(openai.api_resources, name, cls)
+
+    swap_methods(completion, "create", gentrace_config, intercept_chat_completion)
+    swap_methods(acompletion, "acreate", gentrace_config, intercept_chat_completion_async)
+    swap_methods(embedding, "acreate", gentrace_config, intercept_embedding)
 
 
 def annotate_pipeline_handler(


### PR DESCRIPTION
Hi @viveknair @dsafreno 

Noticed you're calling OpenAI. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

I added support for anthropic, palm, cohere, replicate, and huggingface inference endpoints by adding the swap config to also work for the litellm completion and embedding endpoints. The functions map to the openai class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.

Happy to add additional tests / update documentation, if the initial PR looks good to you.