### PR TITLE
feat: Add client instance handling in gentrace lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ dist
 .envrc
 codegen.log
 Brewfile.lock.json
+
+design-docs
+context-artifacts
+gentrace-python.code-workspace
+.DS_Store

--- a/examples/.keep
+++ b/examples/.keep
@@ -1,4 +1,0 @@
-File generated from our OpenAPI spec by Stainless.
-
-This directory can be used to store example files demonstrating usage of this SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "anyio>=3.5.0, <5",
     "distro>=1.7.0, <2",
     "sniffio",
+    "opentelemetry-sdk >= 1.21.0, < 1.33.0",
+    "opentelemetry-exporter-otlp-proto-http >= 1.21.0, < 1.33.0",
+    "opentelemetry-instrumentation >= 0.41b0",
 ]
 requires-python = ">= 3.8"
 classifiers = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -20,8 +20,15 @@ argcomplete==3.1.2
 certifi==2023.7.22
     # via httpcore
     # via httpx
+    # via requests
+charset-normalizer==3.4.2
+    # via requests
 colorlog==6.7.0
     # via nox
+deprecated==1.2.18
+    # via opentelemetry-api
+    # via opentelemetry-exporter-otlp-proto-http
+    # via opentelemetry-semantic-conventions
 dirty-equals==0.6.0
 distlib==0.3.7
     # via virtualenv
@@ -32,6 +39,8 @@ exceptiongroup==1.2.2
     # via pytest
 filelock==3.12.4
     # via virtualenv
+googleapis-common-protos==1.70.0
+    # via opentelemetry-exporter-otlp-proto-http
 h11==0.14.0
     # via httpcore
 httpcore==1.0.2
@@ -42,7 +51,9 @@ httpx==0.28.1
 idna==3.4
     # via anyio
     # via httpx
+    # via requests
 importlib-metadata==7.0.0
+    # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 markdown-it-py==3.0.0
@@ -56,13 +67,37 @@ nest-asyncio==1.6.0
 nodeenv==1.8.0
     # via pyright
 nox==2023.4.22
+opentelemetry-api==1.32.1
+    # via opentelemetry-exporter-otlp-proto-http
+    # via opentelemetry-instrumentation
+    # via opentelemetry-sdk
+    # via opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.32.1
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.32.1
+    # via gentrace
+opentelemetry-instrumentation==0.53b1
+    # via gentrace
+opentelemetry-proto==1.32.1
+    # via opentelemetry-exporter-otlp-proto-common
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.32.1
+    # via gentrace
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.53b1
+    # via opentelemetry-instrumentation
+    # via opentelemetry-sdk
 packaging==23.2
     # via nox
+    # via opentelemetry-instrumentation
     # via pytest
 platformdirs==3.11.0
     # via virtualenv
 pluggy==1.5.0
     # via pytest
+protobuf==5.29.4
+    # via googleapis-common-protos
+    # via opentelemetry-proto
 pydantic==2.10.3
     # via gentrace
 pydantic-core==2.27.1
@@ -77,6 +112,8 @@ python-dateutil==2.8.2
     # via time-machine
 pytz==2023.3.post1
     # via dirty-equals
+requests==2.32.3
+    # via opentelemetry-exporter-otlp-proto-http
 respx==0.22.0
 rich==13.7.1
 ruff==0.9.4
@@ -95,10 +132,16 @@ typing-extensions==4.12.2
     # via anyio
     # via gentrace
     # via mypy
+    # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
     # via pyright
+urllib3==2.4.0
+    # via requests
 virtualenv==20.24.5
     # via nox
+wrapt==1.17.2
+    # via deprecated
+    # via opentelemetry-instrumentation
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements.lock
+++ b/requirements.lock
@@ -18,10 +18,19 @@ anyio==4.4.0
 certifi==2023.7.22
     # via httpcore
     # via httpx
+    # via requests
+charset-normalizer==3.4.2
+    # via requests
+deprecated==1.2.18
+    # via opentelemetry-api
+    # via opentelemetry-exporter-otlp-proto-http
+    # via opentelemetry-semantic-conventions
 distro==1.8.0
     # via gentrace
 exceptiongroup==1.2.2
     # via anyio
+googleapis-common-protos==1.70.0
+    # via opentelemetry-exporter-otlp-proto-http
 h11==0.14.0
     # via httpcore
 httpcore==1.0.2
@@ -31,15 +40,53 @@ httpx==0.28.1
 idna==3.4
     # via anyio
     # via httpx
+    # via requests
+importlib-metadata==8.6.1
+    # via opentelemetry-api
+opentelemetry-api==1.32.1
+    # via opentelemetry-exporter-otlp-proto-http
+    # via opentelemetry-instrumentation
+    # via opentelemetry-sdk
+    # via opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.32.1
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.32.1
+    # via gentrace
+opentelemetry-instrumentation==0.53b1
+    # via gentrace
+opentelemetry-proto==1.32.1
+    # via opentelemetry-exporter-otlp-proto-common
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.32.1
+    # via gentrace
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.53b1
+    # via opentelemetry-instrumentation
+    # via opentelemetry-sdk
+packaging==25.0
+    # via opentelemetry-instrumentation
+protobuf==5.29.4
+    # via googleapis-common-protos
+    # via opentelemetry-proto
 pydantic==2.10.3
     # via gentrace
 pydantic-core==2.27.1
     # via pydantic
+requests==2.32.3
+    # via opentelemetry-exporter-otlp-proto-http
 sniffio==1.3.0
     # via anyio
     # via gentrace
 typing-extensions==4.12.2
     # via anyio
     # via gentrace
+    # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
+urllib3==2.4.0
+    # via requests
+wrapt==1.17.2
+    # via deprecated
+    # via opentelemetry-instrumentation
+zipp==3.21.0
+    # via importlib-metadata

--- a/src/gentrace/__init__.py
+++ b/src/gentrace/__init__.py
@@ -1,5 +1,7 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
+from typing import Any, Union, Callable, cast
+
 from . import types
 from ._types import NOT_GIVEN, Omit, NoneType, NotGiven, Transport, ProxiesTypes
 from ._utils import file_from_path
@@ -17,6 +19,16 @@ from ._client import (
 from ._models import BaseModel
 from ._version import __title__, __version__
 from ._response import APIResponse as APIResponse, AsyncAPIResponse as AsyncAPIResponse
+from .resources import (
+    DatasetsResource,
+    PipelinesResource,
+    TestCasesResource,
+    ExperimentsResource,
+    AsyncDatasetsResource,
+    AsyncPipelinesResource,
+    AsyncTestCasesResource,
+    AsyncExperimentsResource,
+)
 from ._constants import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES, DEFAULT_CONNECTION_LIMITS
 from ._exceptions import (
     APIError,
@@ -36,6 +48,33 @@ from ._exceptions import (
 )
 from ._base_client import DefaultHttpxClient, DefaultAsyncHttpxClient
 from ._utils._logs import setup_logging as _setup_logging
+from .lib.client_instance import _get_sync_client_instance, _get_async_client_instance
+
+
+class _ResourceWrapper:
+    def __init__(self, client_accessor_func: Callable[[], Union[Gentrace, AsyncGentrace]], resource_name: str):
+        """Initializes the resource wrapper."""
+        self._client_accessor_func = client_accessor_func
+        self._resource_name = resource_name
+
+    def __getattr__(self, name: str) -> Any:
+        """Gets an attribute from the underlying resource."""
+        client = self._client_accessor_func()
+        resource_obj = getattr(client, self._resource_name)
+        return getattr(resource_obj, name)
+
+
+pipelines = cast(PipelinesResource, _ResourceWrapper(_get_sync_client_instance, "pipelines"))
+experiments = cast(ExperimentsResource, _ResourceWrapper(_get_sync_client_instance, "experiments"))
+datasets = cast(DatasetsResource, _ResourceWrapper(_get_sync_client_instance, "datasets"))
+test_cases = cast(TestCasesResource, _ResourceWrapper(_get_sync_client_instance, "test_cases"))
+
+pipelines_async = cast(AsyncPipelinesResource, _ResourceWrapper(_get_async_client_instance, "pipelines"))
+experiments_async = cast(AsyncExperimentsResource, _ResourceWrapper(_get_async_client_instance, "experiments"))
+datasets_async = cast(AsyncDatasetsResource, _ResourceWrapper(_get_async_client_instance, "datasets"))
+test_cases_async = cast(AsyncTestCasesResource, _ResourceWrapper(_get_async_client_instance, "test_cases"))
+
+from .lib.init import init
 
 __all__ = [
     "types",
@@ -76,6 +115,9 @@ __all__ = [
     "DEFAULT_CONNECTION_LIMITS",
     "DefaultHttpxClient",
     "DefaultAsyncHttpxClient",
+
+    # Custom library functions
+    "init",
 ]
 
 _setup_logging()

--- a/src/gentrace/lib/.keep
+++ b/src/gentrace/lib/.keep
@@ -1,4 +1,0 @@
-File generated from our OpenAPI spec by Stainless.
-
-This directory can be used to store custom files to expand the SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.

--- a/src/gentrace/lib/client_instance.py
+++ b/src/gentrace/lib/client_instance.py
@@ -1,0 +1,132 @@
+import os
+from typing import Dict, Optional
+
+from .._types import NOT_GIVEN
+from .._client import Gentrace, AsyncGentrace
+from .._exceptions import GentraceError
+
+_sync_client: Optional[Gentrace] = None
+_async_client: Optional[AsyncGentrace] = None
+
+
+def _get_default_options() -> Dict[str, str]:
+    """
+    Fetches default Gentrace options from environment variables.
+
+    Returns:
+        A dictionary containing "bearer_token" and "base_url" if the
+        corresponding GENTRACE_API_KEY and GENTRACE_BASE_URL environment
+        variables are set. Returns an empty dictionary otherwise.
+    """
+    options: Dict[str, str] = {}
+    api_key = os.environ.get("GENTRACE_API_KEY")
+    base_url = os.environ.get("GENTRACE_BASE_URL")
+
+    if api_key:
+        options["bearer_token"] = api_key
+    if base_url:
+        options["base_url"] = base_url
+    return options
+
+
+def _get_default_sync_client() -> Optional[Gentrace]:
+    """
+    Creates a default synchronous Gentrace client using environment variables.
+
+    Returns:
+        A Gentrace client instance if GENTRACE_API_KEY is set, None otherwise.
+    """
+    options = _get_default_options()
+    if "bearer_token" in options:
+        return Gentrace(
+            bearer_token=options["bearer_token"],
+            base_url=options.get("base_url"),  # Can be None
+            timeout=NOT_GIVEN,
+            default_headers=None,
+            default_query=None,
+        )
+    return None
+
+
+def _get_default_async_client() -> Optional[AsyncGentrace]:
+    """
+    Creates a default asynchronous Gentrace client using environment variables.
+
+    Returns:
+        An AsyncGentrace client instance if GENTRACE_API_KEY is set, None otherwise.
+    """
+    options = _get_default_options()
+    if "bearer_token" in options:
+        return AsyncGentrace(
+            bearer_token=options["bearer_token"],
+            base_url=options.get("base_url"),  # Can be None
+            timeout=NOT_GIVEN,
+            default_headers=None,
+            default_query=None,
+        )
+    return None
+
+
+def _get_sync_client_instance() -> Gentrace:
+    """
+    Retrieves the singleton synchronous Gentrace client instance.
+
+    Initializes a default client from environment variables if no client has been
+    explicitly set via init().
+
+    Returns:
+        The Gentrace client instance.
+
+    Raises:
+        GentraceError: If the SDK has not been initialized and GENTRACE_API_KEY
+                       is not found in environment variables.
+    """
+    global _sync_client
+    if _sync_client is None:
+        _sync_client = _get_default_sync_client()
+        if _sync_client is None:
+            raise GentraceError("Gentrace SDK not initialized. Please call gentrace.init() or set GENTRACE_API_KEY.")
+    return _sync_client
+
+
+def _get_async_client_instance() -> AsyncGentrace:
+    """
+    Retrieves the singleton asynchronous Gentrace client instance.
+
+    Initializes a default client from environment variables if no client has been
+    explicitly set via init().
+
+    Returns:
+        The AsyncGentrace client instance.
+
+    Raises:
+        GentraceError: If the SDK has not been initialized and GENTRACE_API_KEY
+                       is not found in environment variables.
+    """
+    global _async_client
+    if _async_client is None:
+        _async_client = _get_default_async_client()
+        if _async_client is None:
+            raise GentraceError("Gentrace SDK not initialized. Please call gentrace.init() or set GENTRACE_API_KEY.")
+    return _async_client
+
+
+def _set_client_instances(sync_client: Optional[Gentrace], async_client: Optional[AsyncGentrace]) -> None:
+    """
+    Sets the global synchronous and asynchronous Gentrace client instances.
+    Can be used to reset clients by passing None.
+
+    Args:
+        sync_client: The synchronous Gentrace client instance or None.
+        async_client: The asynchronous Gentrace client instance or None.
+    """
+    global _sync_client, _async_client
+    _sync_client = sync_client
+    _async_client = async_client
+
+
+__all__ = [
+    "_get_sync_client_instance",
+    "_set_client_instances",
+    "_get_async_client_instance",
+]

--- a/src/gentrace/lib/constants.py
+++ b/src/gentrace/lib/constants.py
@@ -1,0 +1,3 @@
+ANONYMOUS_SPAN_NAME = "anonymous_function"
+
+__all__ = ["ANONYMOUS_SPAN_NAME"] 

--- a/src/gentrace/lib/init.py
+++ b/src/gentrace/lib/init.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, Optional
+
+from gentrace import Gentrace, AsyncGentrace
+
+from .client_instance import _set_client_instances
+
+
+def init(*, bearer_token: Optional[str] = None, base_url: Optional[str] = None, **kwargs: Any) -> None:
+    """
+    Initializes the Gentrace SDK, configuring global client instances.
+
+    This function sets up both synchronous and asynchronous Gentrace clients.
+    If `bearer_token` is not provided, the underlying clients will attempt to use the
+    GENTRACE_API_KEY environment variable. If `base_url` is not provided, they will
+    attempt to use the GENTRACE_BASE_URL environment variable or a default URL.
+
+    All arguments must be passed as keyword arguments.
+
+    Args:
+        bearer_token (Optional[str]): The Gentrace API key (bearer token).
+            If None, GENTRACE_API_KEY environment variable is used by clients.
+        base_url (Optional[str]): The base URL for the Gentrace API. If not provided,
+            it's determined by the client (env variable or default).
+        **kwargs (Any): Additional keyword arguments passed to the underlying
+            `Gentrace` (synchronous) and `AsyncGentrace` (asynchronous)
+            client constructors. This allows for advanced configuration.
+            Common options include `timeout`, `max_retries`, `default_headers`,
+            `default_query`, and `http_client`.
+            If `http_client` is provided, it will be passed to both the synchronous
+            and asynchronous client constructors. Ensure its type is compatible.
+
+            Refer to the constructor signatures of `gentrace.Gentrace` and
+            `gentrace.AsyncGentrace` for a full list of available options.
+
+    Side Effects:
+        Sets the internal singleton client instances used by the SDK, making them
+        available for subsequent API calls through the gentrace library.
+    """
+    constructor_args: Dict[str, Any] = {}
+    if bearer_token is not None:
+        constructor_args["bearer_token"] = bearer_token
+
+    if base_url is not None:
+        constructor_args["base_url"] = base_url
+
+    constructor_args.update(kwargs)
+
+    sync_g_client = Gentrace(**constructor_args)
+    async_g_client = AsyncGentrace(**constructor_args)
+
+    _set_client_instances(sync_g_client, async_g_client)
+
+
+__all__ = ["init"]

--- a/tests/test_lib_init.py
+++ b/tests/test_lib_init.py
@@ -1,0 +1,94 @@
+import sys
+from unittest.mock import patch, MagicMock
+
+from gentrace.lib.init import init as function_under_test
+
+# Get a direct reference to the module where init() is defined and its dependencies are looked up
+init_module_object = sys.modules["gentrace.lib.init"]
+
+# Test functions will now be pytest-style
+# The order of mock arguments corresponds to the patch decorators from bottom to top (applied inside-out)
+
+
+def test_init_with_all_args_and_kwargs() -> None:
+    with patch.object(init_module_object, "Gentrace") as mock_gentrace_cls, patch.object(
+        init_module_object, "AsyncGentrace"
+    ) as mock_async_gentrace_cls, patch.object(init_module_object, "_set_client_instances") as mock_set_instances:
+        mock_sync_client_instance = MagicMock()
+        mock_async_client_instance = MagicMock()
+        mock_gentrace_cls.return_value = mock_sync_client_instance
+        mock_async_gentrace_cls.return_value = mock_async_client_instance
+
+        function_under_test(bearer_token="test_token_val", base_url="http://testserver", timeout=60)
+
+        mock_gentrace_cls.assert_called_once_with(
+            bearer_token="test_token_val", base_url="http://testserver", timeout=60
+        )
+        mock_async_gentrace_cls.assert_called_once_with(
+            bearer_token="test_token_val", base_url="http://testserver", timeout=60
+        )
+        mock_set_instances.assert_called_once_with(mock_sync_client_instance, mock_async_client_instance)
+
+
+def test_init_with_bearer_token_only() -> None:
+    with patch.object(init_module_object, "Gentrace") as mock_gentrace_cls, patch.object(
+        init_module_object, "AsyncGentrace"
+    ) as mock_async_gentrace_cls, patch.object(init_module_object, "_set_client_instances") as mock_set_instances:
+        mock_sync_client_instance = MagicMock()
+        mock_async_client_instance = MagicMock()
+        mock_gentrace_cls.return_value = mock_sync_client_instance
+        mock_async_gentrace_cls.return_value = mock_async_client_instance
+
+        function_under_test(bearer_token="test_token_val")
+
+        mock_gentrace_cls.assert_called_once_with(bearer_token="test_token_val")
+        mock_async_gentrace_cls.assert_called_once_with(bearer_token="test_token_val")
+        mock_set_instances.assert_called_once_with(mock_sync_client_instance, mock_async_client_instance)
+
+
+def test_init_with_base_url_only() -> None:
+    with patch.object(init_module_object, "Gentrace") as mock_gentrace_cls, patch.object(
+        init_module_object, "AsyncGentrace"
+    ) as mock_async_gentrace_cls, patch.object(init_module_object, "_set_client_instances") as mock_set_instances:
+        mock_sync_client_instance = MagicMock()
+        mock_async_client_instance = MagicMock()
+        mock_gentrace_cls.return_value = mock_sync_client_instance
+        mock_async_gentrace_cls.return_value = mock_async_client_instance
+
+        function_under_test(base_url="http://testserver")
+
+        mock_gentrace_cls.assert_called_once_with(base_url="http://testserver")
+        mock_async_gentrace_cls.assert_called_once_with(base_url="http://testserver")
+        mock_set_instances.assert_called_once_with(mock_sync_client_instance, mock_async_client_instance)
+
+
+def test_init_with_no_explicit_args() -> None:
+    with patch.object(init_module_object, "Gentrace") as mock_gentrace_cls, patch.object(
+        init_module_object, "AsyncGentrace"
+    ) as mock_async_gentrace_cls, patch.object(init_module_object, "_set_client_instances") as mock_set_instances:
+        mock_sync_client_instance = MagicMock()
+        mock_async_client_instance = MagicMock()
+        mock_gentrace_cls.return_value = mock_sync_client_instance
+        mock_async_gentrace_cls.return_value = mock_async_client_instance
+
+        function_under_test()
+
+        mock_gentrace_cls.assert_called_once_with()
+        mock_async_gentrace_cls.assert_called_once_with()
+        mock_set_instances.assert_called_once_with(mock_sync_client_instance, mock_async_client_instance)
+
+
+def test_init_with_additional_kwargs() -> None:
+    with patch.object(init_module_object, "Gentrace") as mock_gentrace_cls, patch.object(
+        init_module_object, "AsyncGentrace"
+    ) as mock_async_gentrace_cls, patch.object(init_module_object, "_set_client_instances") as mock_set_instances:
+        mock_sync_client_instance = MagicMock()
+        mock_async_client_instance = MagicMock()
+        mock_gentrace_cls.return_value = mock_sync_client_instance
+        mock_async_gentrace_cls.return_value = mock_async_client_instance
+
+        function_under_test(max_retries=5, custom_option="test_custom")
+
+        mock_gentrace_cls.assert_called_once_with(max_retries=5, custom_option="test_custom")
+        mock_async_gentrace_cls.assert_called_once_with(max_retries=5, custom_option="test_custom")
+        mock_set_instances.assert_called_once_with(mock_sync_client_instance, mock_async_client_instance)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -186,6 +186,7 @@ async def test_special_new_line_character(
     assert sse.event is None
     assert sse.json() == {"content": "  "}
 
+
     sse = await iter_next(iterator)
     assert sse.event is None
     assert sse.json() == {"content": "foo"}


### PR DESCRIPTION
### TL;DR

Add OpenTelemetry tracing support to the Gentrace Python SDK.

### What changed?

- Added OpenTelemetry SDK dependencies to `pyproject.toml`
- Created a new library structure with tracing utilities:
  - `init()` function to initialize the SDK with configuration options
  - Utility functions for handling OpenTelemetry attribute formatting
  - Client instance management for both sync and async clients
- Added `.gitignore` entries for design docs and workspace files
- Updated lock files with new dependencies

