### PR TITLE
feat: Add `@experiment()` decorator for managing lifecycle logic

### DIFF
--- a/src/gentrace/__init__.py
+++ b/src/gentrace/__init__.py
@@ -76,6 +76,7 @@ test_cases_async = cast(AsyncTestCasesResource, _ResourceWrapper(_get_async_clie
 
 from .lib.init import init
 from .lib.traced import traced
+from .lib.experiment import experiment
 from .lib.interaction import interaction
 
 __all__ = [
@@ -118,10 +119,11 @@ __all__ = [
     "DefaultHttpxClient",
     "DefaultAsyncHttpxClient",
 
-    # Custom library functions
+    # Start custom Gentrace exports
     "init",
     "traced",
     "interaction",
+    "experiment",
 ]
 
 _setup_logging()

--- a/src/gentrace/lib/client_handles.py
+++ b/src/gentrace/lib/client_handles.py
@@ -1,0 +1,50 @@
+from typing import Any, Union, Callable, cast
+
+from gentrace import Gentrace, AsyncGentrace
+from gentrace.resources import (
+    DatasetsResource,
+    PipelinesResource,
+    TestCasesResource,
+    ExperimentsResource,
+    AsyncDatasetsResource,
+    AsyncPipelinesResource,
+    AsyncTestCasesResource,
+    AsyncExperimentsResource,
+)
+
+from .client_instance import _get_sync_client_instance, _get_async_client_instance
+
+
+class _ResourceWrapper:
+    def __init__(self, client_accessor_func: Callable[[], Union[Gentrace, AsyncGentrace]], resource_name: str):
+        """Initializes the resource wrapper."""
+        self._client_accessor_func = client_accessor_func
+        self._resource_name = resource_name
+
+    def __getattr__(self, name: str) -> Any:
+        """Gets an attribute from the underlying resource."""
+        client = self._client_accessor_func()
+        resource_obj = getattr(client, self._resource_name)
+        return getattr(resource_obj, name)
+
+
+pipelines = cast(PipelinesResource, _ResourceWrapper(_get_sync_client_instance, "pipelines"))
+experiments = cast(ExperimentsResource, _ResourceWrapper(_get_sync_client_instance, "experiments"))
+datasets = cast(DatasetsResource, _ResourceWrapper(_get_sync_client_instance, "datasets"))
+test_cases = cast(TestCasesResource, _ResourceWrapper(_get_sync_client_instance, "test_cases"))
+
+pipelines_async = cast(AsyncPipelinesResource, _ResourceWrapper(_get_async_client_instance, "pipelines"))
+experiments_async = cast(AsyncExperimentsResource, _ResourceWrapper(_get_async_client_instance, "experiments"))
+datasets_async = cast(AsyncDatasetsResource, _ResourceWrapper(_get_async_client_instance, "datasets"))
+test_cases_async = cast(AsyncTestCasesResource, _ResourceWrapper(_get_async_client_instance, "test_cases"))
+
+__all__ = [
+    "pipelines",
+    "experiments",
+    "datasets",
+    "test_cases",
+    "pipelines_async",
+    "experiments_async",
+    "datasets_async",
+    "test_cases_async",
+]

--- a/src/gentrace/lib/eval.py
+++ b/src/gentrace/lib/eval.py
@@ -1,0 +1,137 @@
+import inspect
+import logging
+import functools
+from typing import Any, Dict, TypeVar, Callable, Optional, Coroutine, overload
+from typing_extensions import ParamSpec
+
+from opentelemetry import trace
+from opentelemetry.trace.status import Status, StatusCode
+
+from .utils import _gentrace_json_dumps  # For safe serialization of output
+from .constants import ANONYMOUS_SPAN_NAME
+from .experiment import ExperimentContext, register_eval_function, get_current_experiment_context
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+_tracer = trace.get_tracer("gentrace.sdk")
+logger = logging.getLogger("gentrace")
+
+RESERVED_METADATA_KEYS = {
+    "gentrace.experiment_id",
+    "gentrace.test_case_name",
+    "gentrace.fn.args",
+    "gentrace.fn.output",
+}
+
+@overload
+def eval(
+    *,
+    name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Callable[[Callable[P, Coroutine[Any, Any, R]]], Callable[P, Coroutine[Any, Any, R]]]:
+    ...
+
+@overload
+def eval(
+    *,
+    name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Callable[[Callable[P, R]], Callable[P, Coroutine[Any, Any, R]]]: # Sync func becomes awaitable
+    ...
+
+def eval(
+    *,
+    name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Callable[[Callable[P, Any]], Callable[P, Coroutine[Any, Any, Any]]]:
+    """
+    Decorator factory to mark a function as a single evaluation test case within an experiment.
+
+    This decorator must be used on a function that is called within the scope of an
+    `@experiment()` decorated function.
+
+    When the decorated function is called:
+    1. It retrieves the current `experiment_id` and `pipeline_id` from the context
+       set by `@experiment()`.
+    2. It creates an OpenTelemetry span representing this specific evaluation.
+       The span is named using the provided `name` argument.
+    3. Attributes `gentrace.experiment_id` and `gentrace.test_case_name` are set on the span.
+    4. Any provided `metadata` is added to the span.
+    5. The decorated function's execution (inputs, output, errors) is captured within this span:
+       - Input arguments are logged as a 'gentrace.fn.args' event with an 'args' key
+       - Function output is logged as a 'gentrace.fn.output' event with an 'output' key
+    6. If the decorated function is synchronous, it is wrapped to be awaitable, fitting into
+       the common asynchronous flow of experiment execution.
+
+    Args:
+        name: A descriptive name for this evaluation test case. This will be used as part
+              of the OTEL span name and as an attribute.
+        metadata: Optional dictionary of arbitrary metadata to attach to this evaluation's span.
+
+    Returns:
+        A decorator that wraps the user's function.
+    """
+    def inner_decorator(func: Callable[P, Any]) -> Callable[P, Coroutine[Any, Any, Any]]:
+        @functools.wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+            experiment_context: Optional[ExperimentContext] = get_current_experiment_context()
+
+            if not experiment_context:
+                func_name = getattr(func, '__name__', ANONYMOUS_SPAN_NAME)
+                raise RuntimeError(
+                    f"@eval(name='{name}') on function '{func_name}' must be called within an active @experiment context."
+                )
+
+            span_name = f"Eval: {name}"
+            
+            with _tracer.start_as_current_span(span_name) as span:
+                span.set_attribute("gentrace.experiment_id", experiment_context["experiment_id"])
+                span.set_attribute("gentrace.test_case_name", span_name)
+
+                if metadata:
+                    for key, value in metadata.items():
+                        if key in RESERVED_METADATA_KEYS:
+                            logger.warning(
+                                f"Metadata key `{key}` is reserved and will be ignored for @eval test case `{name}`. Avoid using reserved keys for metadata."
+                            )
+                            continue
+                        try:
+                            if isinstance(value, (dict, list, tuple)):
+                                span.set_attribute(key, _gentrace_json_dumps(value))
+                            elif value is not None:
+                                span.set_attribute(key, str(value))
+                        except Exception:
+                            span.set_attribute(key, f"[Unserializable metadata: {key}]")
+                
+                if args or kwargs:
+                    input_payload: Dict[str, Any] = {}
+                    if args:
+                        input_payload["args"] = args
+                    if kwargs:
+                        input_payload["kwargs"] = kwargs
+                    span.add_event("gentrace.fn.args", {"args": _gentrace_json_dumps(input_payload)})
+
+
+                try:
+                    if inspect.iscoroutinefunction(func):
+                        result = await func(*args, **kwargs)
+                    else:
+                        result = func(*args, **kwargs)
+                    
+                    span.add_event("gentrace.fn.output", {"output": _gentrace_json_dumps(result)})
+                    return result
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(Status(StatusCode.ERROR, description=str(e)))
+                    span.set_attribute("error.type", e.__class__.__name__)
+                    raise
+        
+        # Register the OpenTelemetry-instrumented wrapper for auto-execution
+        # by the @experiment decorator.
+        register_eval_function(wrapper)
+        
+        return wrapper
+    return inner_decorator
+
+__all__ = ["eval"] 

--- a/src/gentrace/lib/experiment.py
+++ b/src/gentrace/lib/experiment.py
@@ -1,0 +1,195 @@
+import inspect
+import logging
+import functools
+import contextvars
+from typing import Any, Dict, List, TypeVar, Callable, Optional, Coroutine
+from typing_extensions import ParamSpec, TypedDict
+
+from .experiment_control import start_experiment_api, finish_experiment_api
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+logger = logging.getLogger("gentrace")
+
+class ExperimentContext(TypedDict):
+    """
+    Represents the context for an experiment run. This context is stored in
+    a ContextVar to make the experiment ID and pipeline ID available throughout
+    the asynchronous execution flow.
+    """
+    experiment_id: str
+    pipeline_id: str
+
+experiment_context_var: contextvars.ContextVar[Optional[ExperimentContext]] = \
+    contextvars.ContextVar("gentrace_experiment_context", default=None)
+
+# Context variable to hold the list of eval functions registered for the current experiment
+_experiment_eval_functions_var: contextvars.ContextVar[Optional[List[Callable[[], Any]]]] = \
+    contextvars.ContextVar("gentrace_experiment_eval_functions", default=None)
+
+def get_current_experiment_context() -> Optional[ExperimentContext]:
+    """
+    Retrieves the ExperimentContext (experiment_id, pipeline_id) from the 
+    current asynchronous context, if an experiment is active.
+
+    Returns:
+        The current ExperimentContext or None if not within an experiment() context.
+    """
+    return experiment_context_var.get()
+
+def register_eval_function(func: Callable[[], Any]) -> None:
+    """
+    Registers an evaluation function to be run by the current experiment.
+    This function is intended to be called by an @eval decorator.
+    """
+    registry = _experiment_eval_functions_var.get()
+    if registry is None:
+        # This might happen if @eval is used outside an @experiment.
+        # Depending on desired strictness, this could raise an error or log a warning.
+        logger.warning(
+            f"The @eval decorator was used on function `{getattr(func, '__name__', 'unknown')}` "
+            f"outside of an active @experiment context. This @eval function will not be automatically executed. Ensure @eval is called within an @experiment decorated function."
+        )
+        return
+    registry.append(func)
+
+class ExperimentOptions(TypedDict, total=False):
+    """ Optional parameters for running an experiment. """
+    name: Optional[str] 
+    """Optional name for the experiment run. This will be used as the name for the root OpenTelemetry span."""
+    metadata: Optional[Dict[str, Any]] 
+    """User-defined metadata for the experiment. This will be added as attributes to the root OpenTelemetry span."""
+
+def experiment(
+    *, 
+    pipeline_id: str,
+    options: Optional[ExperimentOptions] = None,
+) -> Callable[[Callable[P, Any]], Callable[P, Coroutine[Any, Any, Any]]]:
+    """
+    A decorator factory that wraps a function to manage a Gentrace Experiment lifecycle.
+    This is the primary way to define a scope for running evaluations.
+
+    When a function is decorated with `@experiment`:
+    1.  A new Gentrace Experiment run is started by calling the Gentrace API. The optional
+        `name` and `metadata` from `options` are passed to this API call.
+    2.  The `experiment_id` (obtained from the API) and `pipeline_id` are stored in an
+        asynchronous context variable. This context is accessible via
+        `get_current_experiment_context()` within the decorated function.
+    3.  The primary use of this decorated function is to serve as a context for calling
+        evaluation utilities like `eval()` and `eval_dataset()`. These utilities,
+        when called within the decorated function, will:
+        a.  Access the `experiment_id` and `pipeline_id` from the context.
+        b.  Typically create their own OpenTelemetry spans for individual test cases or
+            evaluations, tagging these spans with the `experiment_id`.
+            (Note: This `@experiment` decorator itself does NOT create an overarching
+            OpenTelemetry span for the entire experiment function. OTEL span creation
+            is deferred to the evaluation utilities like `eval` or functions
+            decorated with `@traced` called within this experiment context).
+    4.  If the decorated function is synchronous, it will be run in a way that integrates
+        with the surrounding asynchronous operations, and the decorated function will
+        become awaitable.
+    5.  Upon completion or error of the decorated function, the Gentrace Experiment run is
+        finalized via an API call to Gentrace.
+
+    Args:
+        pipeline_id: The ID of the pipeline to associate with this experiment.
+        options: Optional parameters for the Gentrace Experiment entity:
+            name (Optional[str]): A name for the Gentrace Experiment. This is passed to the
+                                  Gentrace API.
+            metadata (Optional[Dict[str, Any]]): User-defined metadata for the Gentrace Experiment.
+                                               Passed to the Gentrace API.
+
+    Returns:
+        A decorator that wraps the user's function, transforming it into an awaitable
+        that executes the experiment lifecycle logic.
+
+    Usage Example:
+        ```python
+        from gentrace import experiment, eval, compose_email
+
+        @experiment(pipeline_id="<uuid>")
+        async def email_evals():
+
+            @eval
+            def should_include_hello(message: str) -> str:
+                email = compose_email(
+                    subject="Hello",
+                    body="Hello, how are you?",
+                    to="test@example.com",
+                    from_="test@example.com",
+                )
+
+                assert "Hello" in email
+                return email
+            
+        asyncio.run(email_evals())
+        ```
+    """
+
+    def inner_decorator(func: Callable[P, Any]) -> Callable[P, Coroutine[Any, Any, Any]]:
+        @functools.wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+            exp_name_option = options.get("name") if options else None
+            user_metadata = options.get("metadata") if options else None
+
+            experiment_id_val: Optional[str] = None
+            try:
+                experiment_id_val = await start_experiment_api(
+                    pipelineId=pipeline_id, name=exp_name_option, metadata=user_metadata
+                )
+            except Exception as e:
+                logger.error(f"Failed to start Gentrace experiment via API. Details: {e}")
+                raise
+
+            if not experiment_id_val:
+                raise RuntimeError("Failed to obtain experiment_id from API.")
+
+            context_data: ExperimentContext = {
+                "experiment_id": experiment_id_val,
+                "pipeline_id": pipeline_id,
+            }
+            
+            token = experiment_context_var.set(context_data)
+            
+            result: Optional[Any] = None
+            current_eval_functions: List[Callable[[], Any]] = []
+            eval_registry_token: Optional[contextvars.Token[Optional[List[Callable[[], Any]]]]] = None
+
+            try:
+                # Set up the registry for @eval functions defined within this experiment
+                eval_registry_token = _experiment_eval_functions_var.set(current_eval_functions)
+
+                if inspect.iscoroutinefunction(func):
+                    result = await func(*args, **kwargs)
+                else:
+                    result = func(*args, **kwargs)
+                
+                # After the main function has run, execute registered @eval functions
+                if current_eval_functions:
+                    logger.debug(f"Experiment `{exp_name_option or pipeline_id}`: Executing {len(current_eval_functions)} registered @eval function(s).")
+                    for i, eval_func in enumerate(current_eval_functions):
+                        eval_name = getattr(eval_func, '__name__', f'eval_function_{i+1}')
+                        try:
+                            logger.debug(f"Executing @eval function: `{eval_name}`.")
+                            if inspect.iscoroutinefunction(eval_func):
+                                await eval_func()
+                            else:
+                                eval_func()
+                            logger.debug(f"@eval function `{eval_name}` completed successfully.")
+                        except AssertionError as e:
+                            logger.error(f"@eval function `{eval_name}` failed with an AssertionError. Details: {e}")
+                        except Exception as e:
+                            logger.error(f"@eval function `{eval_name}` encountered an unexpected error. Details: {e}")
+            finally:
+                if eval_registry_token:
+                    _experiment_eval_functions_var.reset(eval_registry_token)
+                experiment_context_var.reset(token)
+                if experiment_id_val:
+                    await finish_experiment_api(id=experiment_id_val)
+            
+            return result
+        return wrapper
+    return inner_decorator
+
+__all__ = ["experiment", "get_current_experiment_context", "ExperimentContext", "ExperimentOptions", "register_eval_function"] 

--- a/src/gentrace/lib/experiment_control.py
+++ b/src/gentrace/lib/experiment_control.py
@@ -1,0 +1,76 @@
+import logging
+from typing import Any, Dict, Union, Literal, Optional
+
+from .._types import NOT_GIVEN
+from .client_handles import experiments_async
+
+logger = logging.getLogger("gentrace")
+
+"""
+This module provides the core experiment control functionality for the Gentrace Python SDK.
+It includes types and functions for starting and finishing experiments via the Gentrace API.
+"""
+
+async def start_experiment_api(
+    *,
+    pipelineId: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    name: Optional[str] = None,
+) -> str:
+    """
+    Starts a new experiment run by creating an experiment record via the Gentrace API.
+    
+    Args:
+        pipelineId: The ID of the pipeline to create the experiment for.
+        metadata: Optional metadata for the experiment.
+        name: Friendly experiment name.
+               
+    Returns:
+        str: The unique ID of the created experiment run.
+    """
+    logger.debug(f"Attempting to start Gentrace experiment via API for pipeline ID `{pipelineId}` with name `{name}`.")
+    experiment = await experiments_async.create(
+        pipeline_id=pipelineId,
+        metadata=metadata if metadata is not None else NOT_GIVEN,
+        name=name if name is not None else NOT_GIVEN,
+    )
+    
+    return experiment.id
+
+async def finish_experiment_api(*, id: str, error: Optional[Union[Exception, str]] = None) -> None:
+    """
+    Finishes an experiment run by updating its status via the Gentrace API.
+    
+    Args:
+        id: The ID of the experiment to finish.
+        error: Optional error information. If provided, it will be logged.
+    """
+    logger.debug(f"Attempting to finish Gentrace experiment via API for experiment ID `{id}`.")
+    
+    status_to_set: Literal["EVALUATING"] = "EVALUATING"
+    # In the future, if the API supports errorMessage, it would be set here.
+    # For now, we will log the error if present.
+
+    if error:
+        error_message = str(error) if isinstance(error, Exception) else error
+        logger.info(f"Finishing Gentrace experiment `{id}` with a recorded error. Error details: {error_message}")
+        # If there was an error, the status on the backend might be handled differently
+        # or this might imply a different status if the API allowed. For now, we proceed
+        # to set it to EVALUATING as per Node.js SDK's apparent behavior, or this
+        # could be a point to set a specific "ERROR" status if available.
+
+    try:
+        await experiments_async.update(
+            id,
+            status=status_to_set,
+        )
+        logger.info(f"Successfully updated Gentrace experiment `{id}` to status `{status_to_set}` via API.")
+    except Exception as e:
+        logger.error(f"Failed to update Gentrace experiment `{id}` status via API. Details: {e}")
+        # Optionally re-raise or handle as appropriate for the SDK's error handling strategy
+        raise
+
+__all__ = [
+    "start_experiment_api",
+    "finish_experiment_api",
+]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,372 @@
+import sys
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pytest import LogCaptureFixture
+
+from gentrace.lib.experiment import (
+    ExperimentOptions,
+    experiment,
+    register_eval_function,
+    get_current_experiment_context,
+)
+
+# Get a direct reference to the module where experiment() is defined
+experiment_module_object = sys.modules["gentrace.lib.experiment"]
+
+
+@pytest.mark.asyncio
+async def test_experiment_decorator_simple_async_function() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "test_experiment_id"
+
+        @experiment(pipeline_id="test_pipeline")
+        async def sample_async_function() -> str:
+            return "result"
+
+        result = await sample_async_function()
+
+        assert result == "result"
+        mock_start_api.assert_called_once_with(pipelineId="test_pipeline", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="test_experiment_id")
+
+
+@pytest.mark.asyncio
+async def test_experiment_decorator_simple_sync_function() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "test_experiment_id_sync"
+
+        @experiment(pipeline_id="test_pipeline_sync")
+        def sample_sync_function() -> str:
+            return "sync_result"
+
+        # Even though sample_sync_function is sync, the decorator makes it awaitable
+        result = await sample_sync_function()
+
+        assert result == "sync_result"
+        mock_start_api.assert_called_once_with(pipelineId="test_pipeline_sync", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="test_experiment_id_sync")
+
+
+@pytest.mark.asyncio
+async def test_experiment_context_is_set_and_retrievable() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_context_test"
+
+        @experiment(pipeline_id="pipeline_for_context")
+        async def function_with_context_check() -> None:
+            context = get_current_experiment_context()
+            assert context is not None
+            assert context["experiment_id"] == "exp_id_context_test"
+            assert context["pipeline_id"] == "pipeline_for_context"
+
+            # Check context variable directly too
+            raw_context = experiment_module_object.experiment_context_var.get()
+            assert raw_context is not None
+            assert raw_context["experiment_id"] == "exp_id_context_test"
+            assert raw_context["pipeline_id"] == "pipeline_for_context"
+
+        await function_with_context_check()
+
+        # Context should be reset outside the function
+        assert experiment_module_object.experiment_context_var.get() is None
+        assert get_current_experiment_context() is None
+
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_for_context", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_context_test")
+
+
+@pytest.mark.asyncio
+async def test_get_current_experiment_context_outside_experiment() -> None:
+    assert get_current_experiment_context() is None
+    assert experiment_module_object.experiment_context_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_experiment_decorator_with_options() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_options_test"
+        experiment_name = "My Test Experiment"
+        experiment_metadata = {"version": "1.0", "user": "test_user"}
+
+        options: ExperimentOptions = {
+            "name": experiment_name,
+            "metadata": experiment_metadata,
+        }
+
+        @experiment(pipeline_id="pipeline_with_options", options=options)
+        async def function_with_options() -> str:
+            return "options_result"
+
+        result = await function_with_options()
+
+        assert result == "options_result"
+        mock_start_api.assert_called_once_with(
+            pipelineId="pipeline_with_options",
+            name=experiment_name,
+            metadata=experiment_metadata,
+        )
+        mock_finish_api.assert_called_once_with(id="exp_id_options_test")
+
+
+@pytest.mark.asyncio
+async def test_experiment_decorator_start_api_fails() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.side_effect = ValueError("API start failed")
+
+        @experiment(pipeline_id="pipeline_api_fail")
+        async def function_where_api_fails() -> str:
+            # This part should not be reached
+            return "should_not_return"
+
+        with pytest.raises(ValueError, match="API start failed"):
+            await function_where_api_fails()
+
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_api_fail", name=None, metadata=None)
+        mock_finish_api.assert_not_called()
+        # Context should not be set if start_api failed before setting it
+        assert experiment_module_object.experiment_context_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_experiment_with_sync_eval_function() -> None:
+    mock_eval_function = MagicMock()
+
+    def simple_eval() -> str:
+        mock_eval_function()
+        return "eval_result"
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_sync_eval"
+
+        @experiment(pipeline_id="pipeline_sync_eval")
+        async def experiment_with_eval() -> str:
+            # Simulate @eval decorator by calling register_eval_function directly
+            # In real code, @eval would call this.
+            register_eval_function(simple_eval)
+            return "main_result"
+
+        result = await experiment_with_eval()
+
+        assert result == "main_result"
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_sync_eval", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_sync_eval")
+        mock_eval_function.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_experiment_with_async_eval_function() -> None:
+    mock_async_eval_function = AsyncMock()
+
+    async def simple_async_eval() -> str:
+        await mock_async_eval_function()
+        return "async_eval_result"
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_async_eval"
+
+        @experiment(pipeline_id="pipeline_async_eval")
+        async def experiment_with_async_eval() -> str:
+            register_eval_function(simple_async_eval)
+            return "main_async_result"
+
+        result = await experiment_with_async_eval()
+
+        assert result == "main_async_result"
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_async_eval", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_async_eval")
+        mock_async_eval_function.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_experiment_with_multiple_eval_functions() -> None:
+    mock_eval1 = MagicMock()
+    mock_eval2_async = AsyncMock()
+
+    def sync_eval_1() -> None:
+        mock_eval1()
+
+    async def async_eval_2() -> None:
+        await mock_eval2_async()
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_multiple_eval"
+
+        @experiment(pipeline_id="pipeline_multiple_eval")
+        async def experiment_with_multiple_evals() -> str:
+            register_eval_function(sync_eval_1)
+            register_eval_function(async_eval_2)
+            return "main_multiple_result"
+
+        result = await experiment_with_multiple_evals()
+
+        assert result == "main_multiple_result"
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_multiple_eval", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_multiple_eval")
+        mock_eval1.assert_called_once()
+        mock_eval2_async.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_experiment_eval_function_raises_exception(caplog: LogCaptureFixture) -> None:
+    eval_exception = ValueError("Eval failed")
+
+    def faulty_eval() -> None:
+        raise eval_exception
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_eval_fail"
+
+        @experiment(pipeline_id="pipeline_eval_fail")
+        async def experiment_where_eval_fails() -> str:
+            register_eval_function(faulty_eval)
+            return "main_result_eval_fail"
+
+        result = await experiment_where_eval_fails()
+
+        assert result == "main_result_eval_fail"
+
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_eval_fail", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_eval_fail")
+
+        # Check that the error was logged
+        assert len(caplog.records) >= 1
+        found_log = False
+        for record in caplog.records:
+            if (
+                record.levelname == "ERROR"
+                and "@eval function `faulty_eval` encountered an unexpected error. Details: Eval failed"
+                in record.message
+            ):
+                found_log = True
+                break
+        assert found_log, "Expected error log message not found for faulty_eval"
+
+
+def test_register_eval_function_outside_experiment_context(caplog: LogCaptureFixture) -> None:
+    mock_standalone_eval = MagicMock()
+
+    def standalone_eval_func() -> None:
+        mock_standalone_eval()
+
+    assert experiment_module_object.experiment_context_var.get() is None
+    assert experiment_module_object._experiment_eval_functions_var.get() is None
+
+    # Clear previous logs if any, and set level to capture WARNING
+    caplog.clear()
+    caplog.set_level(logging.WARNING)  # Ensure WARNING level is captured
+
+    register_eval_function(standalone_eval_func)
+
+    mock_standalone_eval.assert_not_called()
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "WARNING"
+    assert "The @eval decorator was used on function `standalone_eval_func`" in record.message
+    assert "outside of an active @experiment context" in record.message
+    assert "This @eval function will not be automatically executed" in record.message
+
+
+@pytest.mark.asyncio
+async def test_experiment_with_mixed_eval_outcomes(caplog: LogCaptureFixture) -> None:
+    mock_success_indicator = MagicMock()
+    mock_assertion_before_error = MagicMock()
+    mock_value_before_error = MagicMock()
+    # This mock should not be called as it's after an error in its eval function
+    mock_after_error_in_eval = MagicMock()
+
+    def successful_eval() -> str:
+        mock_success_indicator()
+        return "success"
+
+    def assertion_error_eval() -> None:
+        mock_assertion_before_error()
+        raise AssertionError("This is a test assertion error")
+
+    async def value_error_eval() -> None:
+        mock_value_before_error()
+        raise ValueError("This is a test value error")
+
+    caplog.set_level(logging.DEBUG)  # Capture DEBUG and above
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_mixed_outcomes"
+
+        @experiment(pipeline_id="pipeline_mixed_outcomes", options={"name": "MixedTest"})
+        async def experiment_with_mixed_evals() -> str:
+            register_eval_function(successful_eval)
+            register_eval_function(assertion_error_eval)
+            register_eval_function(value_error_eval)
+            return "main_mixed_result"
+
+        main_result = await experiment_with_mixed_evals()
+
+        assert main_result == "main_mixed_result"
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_mixed_outcomes", name="MixedTest", metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_mixed_outcomes")
+
+        mock_success_indicator.assert_called_once()
+        mock_assertion_before_error.assert_called_once()
+        mock_value_before_error.assert_called_once()
+        mock_after_error_in_eval.assert_not_called()
+
+        logs = [(r.levelname, r.message) for r in caplog.records]
+
+        assert ("DEBUG", "Experiment `MixedTest`: Executing 3 registered @eval function(s).") in logs
+
+        assert ("DEBUG", "Executing @eval function: `successful_eval`.") in logs
+        assert ("DEBUG", "@eval function `successful_eval` completed successfully.") in logs
+
+        assert ("DEBUG", "Executing @eval function: `assertion_error_eval`.") in logs
+        assert (
+            "ERROR",
+            "@eval function `assertion_error_eval` failed with an AssertionError. Details: This is a test assertion error\nassert False",
+        ) in logs
+
+        assert ("DEBUG", "Executing @eval function: `value_error_eval`.") in logs
+        assert (
+            "ERROR",
+            "@eval function `value_error_eval` encountered an unexpected error. Details: This is a test value error",
+        ) in logs

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,12 +1,13 @@
-import unittest
-from unittest.mock import MagicMock, patch
-import asyncio
 import uuid
+import asyncio
+import unittest
 from typing import Any, Dict, Tuple, Callable
+from unittest.mock import MagicMock, patch
 
-from gentrace.lib.interaction import interaction
-from opentelemetry.trace.status import StatusCode, Status
+from opentelemetry.trace.status import Status, StatusCode
+
 from gentrace.lib.utils import _gentrace_json_dumps
+from gentrace.lib.interaction import interaction
 
 
 class TestInteraction(unittest.TestCase):

--- a/tests/test_lib_init.py
+++ b/tests/test_lib_init.py
@@ -1,5 +1,5 @@
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from gentrace.lib.init import init as function_under_test
 

--- a/tests/test_traced.py
+++ b/tests/test_traced.py
@@ -1,10 +1,11 @@
-import unittest
-from unittest.mock import MagicMock, patch
 import uuid
+import unittest
 from typing import Tuple
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.trace.status import Status, StatusCode
 
 from gentrace.lib.traced import traced
-from opentelemetry.trace.status import StatusCode, Status
 
 
 class TestTraced(unittest.TestCase):


### PR DESCRIPTION
# Add experiment decorator for managing evaluation lifecycle

### TL;DR

Introduces a new `@experiment` decorator that manages the lifecycle of evaluation runs, providing context for test cases.

### What changed?

- Added a new `experiment.py` module with the following components:
  - `@experiment` decorator that wraps functions to create a managed evaluation context
  - Context management using `contextvars` to track experiment state across async flows
  - API client placeholders for starting and finishing experiments
  - Helper function `get_current_experiment_context()` to access the current experiment data
  - Type definitions for experiment parameters and context

- Updated `utils.py` with a new `is_pydantic_v1()` utility function to detect Pydantic version

### How to test?

```python
from gentrace import experiment

@experiment(pipeline_id="1b926783-0fbe-4760-a59f-30c94494b0c3", 
            options={"name": "Test Run", "metadata": {"version": "1.0"}})
async def run_my_evaluations():
    # Run evaluations here
    pass
    
# Execute the experiment
import asyncio
asyncio.run(run_my_evaluations())
```

### Why make this change?

This change provides a structured way to manage evaluation runs by:
- Creating a clear boundary for experiment execution
- Automatically handling experiment lifecycle (start/finish)
- Maintaining context across async operations for tracking purposes
- Enabling proper attribution of evaluations to specific experiment runs
- Supporting metadata and naming for better organization of evaluation results