### PR TITLE
feat: Add `eval_dataset()` function underneath `experiment()`

### DIFF
--- a/examples/combined.py
+++ b/examples/combined.py
@@ -1,0 +1,171 @@
+"""
+This example script demonstrates a combined usage of various Gentrace Python SDK features,
+including @eval, @interaction, and eval_dataset within a single @experiment.
+It showcases:
+
+- Setting up Gentrace and OpenTelemetry for tracing.
+- Defining an experiment that orchestrates multiple evaluation types.
+- Using `eval_dataset` for batch evaluations against a dataset.
+- Using the `@eval` decorator for individual, ad-hoc evaluation steps (both sync and async).
+- Using the `@interaction` decorator to trace specific function calls as part of the experiment.
+
+To run this example, ensure the following environment variables are set:
+    GENTRACE_API_KEY: Your Gentrace API token for authentication.
+    GENTRACE_BASE_URL: The base URL for your Gentrace instance (e.g., https://gentrace.ai/api).
+    GENTRACE_DATASET_ID: (Optional) The ID of the dataset to use for `eval_dataset`.
+    GENTRACE_PIPELINE_ID: The ID of the pipeline to associate with this experiment.
+"""
+
+import os
+import atexit
+import asyncio
+from typing import Any, Dict, Sequence
+from typing_extensions import TypedDict
+
+# OpenTelemetry API and SDK components
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+from gentrace.lib.eval import eval
+from gentrace.lib.init import init
+from gentrace.lib.experiment import experiment
+from gentrace.lib.interaction import interaction
+from gentrace.lib.eval_dataset import TestInput, eval_dataset
+
+gentrace_api_key = os.getenv("GENTRACE_API_KEY", "")
+gentrace_base_url = os.getenv("GENTRACE_BASE_URL", "")
+dataset_id = os.getenv("GENTRACE_DATASET_ID", "")
+pipeline_id = os.getenv("GENTRACE_PIPELINE_ID", "")
+
+if not gentrace_api_key:
+    raise ValueError("GENTRACE_API_KEY environment variable not set.")
+
+if not gentrace_base_url:
+    raise ValueError(
+        "GENTRACE_BASE_URL environment variable not set. Please set it to your Gentrace API endpoint (e.g., https://gentrace.ai/api)."
+    )
+
+if not pipeline_id:
+    raise ValueError("GENTRACE_PIPELINE_ID environment variable not set.")
+
+resource = Resource(attributes={"service.name": "example-combined-eval"})
+
+tracer_provider = TracerProvider(resource=resource)
+
+otlp_headers: Dict[str, str] = {}
+if gentrace_api_key:
+    otlp_headers["Authorization"] = f"Bearer {gentrace_api_key}"
+else:
+    print("Warning: GENTRACE_API_KEY environment variable not set.")
+
+span_exporter = OTLPSpanExporter(endpoint=f"{gentrace_base_url}/otel/v1/traces", headers=otlp_headers)
+
+span_processor = SimpleSpanProcessor(span_exporter)
+tracer_provider.add_span_processor(span_processor)
+
+trace.set_tracer_provider(tracer_provider)
+
+tracer = trace.get_tracer(__name__)
+
+init(bearer_token=gentrace_api_key, base_url=gentrace_base_url)
+
+
+class InteractionInput(TypedDict):
+    prompt: str
+    temperature: float
+
+
+class InteractionOutput(TypedDict):
+    result: str
+
+
+def dataset_interaction(inputs: InteractionInput) -> InteractionOutput:
+    result_text = f"Interaction based on '{inputs['prompt'][:20]}...' at temp {inputs['temperature']}"
+    return InteractionOutput(result=result_text)
+
+
+async def fetch_dataset_cases() -> Sequence[TestInput[InteractionInput]]:
+    print(f"Simulating fetch for dataset {dataset_id}")
+    return [
+        TestInput[InteractionInput](
+            name="Sample Case 1", inputs={"prompt": "Write a story about a dragon.", "temperature": 0.7}
+        ),
+        TestInput[InteractionInput](
+            name="Sample Case 2: Short Prompt", inputs={"prompt": "Summarize AI.", "temperature": 0.5}
+        ),
+    ]
+
+
+@interaction(pipeline_id=pipeline_id, name="Simulated LLM Call")
+async def simulated_llm_call(prompt: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    print(f"Running @interaction function with prompt: '{prompt[:30]}...'")
+    await asyncio.sleep(0.15)
+    response = {
+        "completion": f"Generated text based on prompt: {prompt[:15]}...",
+        "model_used": config.get("model", "default-model"),
+        "tokens": len(prompt) // 4,
+    }
+    print("@interaction function finished.")
+    return response
+
+
+@experiment(pipeline_id=pipeline_id)
+async def run_combined_evaluation() -> None:
+    @eval(name="Individual Eval Step 1 (Sync)", metadata={"type": "simple_check", "value": 10})
+    def individual_sync_eval(input_val: int) -> Dict[str, Any]:
+        print(f"Running sync @eval function with input: {input_val}")
+        return {"status": "completed", "input_received": input_val, "result_value": input_val * 2}
+
+    await individual_sync_eval(10)
+
+    @eval(name="Individual Eval Step 2 (Async)")
+    async def individual_async_eval() -> str:
+        print("Running async @eval function")
+        await asyncio.sleep(0.1)
+        return "Async evaluation finished successfully."
+
+    await individual_async_eval()
+
+    print(f"Starting combined evaluation for pipeline {pipeline_id}...")
+
+    print("\nRunning eval_dataset...")
+    dataset_results = await eval_dataset(
+        data=fetch_dataset_cases,
+        interaction=dataset_interaction,
+    )
+    print(f"eval_dataset completed. Results: {dataset_results}")
+
+    interaction_result = await simulated_llm_call(
+        prompt="Generate a creative summary of recent AI advancements.",
+        config={"model": "fancy-ai-model-v3", "temperature": 0.6},
+    )
+    print(f"@interaction function returned: {interaction_result}")
+
+    print("Combined evaluation steps initiated. Check Gentrace dashboard.")
+
+
+async def main() -> None:
+    await run_combined_evaluation()
+
+
+if __name__ == "__main__":
+    # Ensure OTel SDK is shutdown gracefully to flush traces
+    atexit.register(tracer_provider.shutdown)
+    print("Registered OTel SDK shutdown handler with atexit.")
+
+    print("Running combined @eval and eval_dataset example...")
+
+    try:
+        asyncio.run(main())
+    except RuntimeError as e:
+        if "cannot be called from a running event loop" in str(e):
+            loop = asyncio.get_running_loop()
+            loop.create_task(main())
+        else:
+            raise
+
+    print("Finished running combined example.")
+    print("Check your Gentrace dashboard to see the traces.")

--- a/examples/eval.py
+++ b/examples/eval.py
@@ -1,0 +1,171 @@
+"""
+This example script demonstrates how to use the Gentrace Python SDK
+to define and run experiments with evaluations. It showcases:
+
+- Setting up Gentrace and OpenTelemetry for tracing.
+- Defining an experiment using the @experiment decorator.
+- Defining evaluation test cases within the experiment using the @eval decorator.
+- Dynamically invoking these evaluation test cases.
+
+To run this example, ensure the following environment variables are set:
+    GENTRACE_API_KEY: Your Gentrace API token for authentication.
+    GENTRACE_BASE_URL: The base URL for your Gentrace instance (e.g., http://localhost:3000 or https://gentrace.ai/api).
+"""
+
+import os
+import asyncio
+import logging
+from typing import Any, Dict, List
+
+try:
+    from gentrace.lib.eval import eval
+    from gentrace.lib.init import init
+    from gentrace.lib.experiment import ExperimentOptions, experiment
+except ImportError:
+    import sys
+
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+    from gentrace.lib.eval import eval
+    from gentrace.lib.init import init
+    from gentrace.lib.experiment import ExperimentOptions, experiment
+
+gentrace_api_key = os.getenv("GENTRACE_API_KEY")
+gentrace_base_url = os.getenv("GENTRACE_BASE_URL")
+
+if not gentrace_api_key:
+    raise ValueError("GENTRACE_API_KEY environment variable not set.")
+if not gentrace_base_url:
+    raise ValueError("GENTRACE_BASE_URL environment variable not set.")
+
+init(
+    base_url=gentrace_base_url,
+    bearer_token=gentrace_api_key,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+PIPELINE_ID = "26d64c23-e38c-56fd-9b45-9adc87de797b"
+
+
+def compose_email(subject: str, body: str, to: str, from_: str) -> str:
+    """Formats an email string with given subject, body, recipient, and sender.
+
+    This is a placeholder function for demonstration purposes within the experiment.
+
+    Args:
+        subject: The subject line of the email.
+        body: The main content of the email.
+        to: The recipient's email address.
+        from_: The sender's email address.
+
+    Returns:
+        A string representing the formatted email.
+    """
+    return f"To: {to}\\nFrom: {from_}\\nSubject: {subject}\\n\\n{body}"
+
+
+experiment_options: ExperimentOptions = {
+    "name": "Dynamic Eval Experiment",
+    "metadata": {"environment": "example", "version": "2.0"},
+}
+
+
+@experiment(pipeline_id=PIPELINE_ID, options=experiment_options)
+async def run_evals_experiment() -> None:
+    logger.info(f"Running experiment with options: {experiment_options}")
+
+    @eval(name="Email Content Test 1", metadata={"variant": "A"})
+    async def check_email_variant_A(subject: str, body: str, expected_keywords: List[str]) -> Dict[str, Any]:
+        email_content = compose_email(subject=subject, body=body, to="test@example.com", from_="sender@example.com")
+        for keyword in expected_keywords:
+            assert keyword in email_content, f"Keyword '{keyword}' not found in email variant A"
+        logger.info(f"    [{check_email_variant_A.__name__}] PASSED.")
+        return {"email_length": len(email_content), "subject": subject, "body": body}
+
+    await check_email_variant_A(
+        subject="Welcome Email A",
+        body="This is variant A of our welcome email.",
+        expected_keywords=["Welcome Email A", "variant A"],
+    )
+
+    @eval(name="Email Content Test 2 (Sync)", metadata={"variant": "B"})
+    async def check_email_variant_B_sync(subject: str, body: str, disallowed_phrases: List[str]) -> Dict[str, Any]:
+        email_content = compose_email(subject=subject, body=body, to="user@example.net", from_="marketing@example.com")
+        for phrase in disallowed_phrases:
+            assert phrase not in email_content, f"Disallowed phrase '{phrase}' found in email variant B"
+        logger.info(f"    [{check_email_variant_B_sync.__name__}] PASSED.")
+        return {"email_length": len(email_content), "subject": subject, "body": body, "outcome": "sync success"}
+
+    await check_email_variant_B_sync(
+        subject="Special Offer B",
+        body="Variant B: Get your special discount now!",
+        disallowed_phrases=["spam", "free money"],
+    )
+
+    @eval(name="Error Case Test", metadata={"test_type": "failure_simulation"})
+    async def check_email_potentially_failing(subject: str) -> Dict[str, str]:
+        if not subject:
+            raise ValueError("Subject cannot be empty for this test.")
+        logger.info(f"    [{check_email_potentially_failing.__name__}] Processed (expected to fail or be caught).")
+        return {"status": "ran_before_potential_error", "subject_used": subject}
+
+    try:
+        await check_email_potentially_failing(subject="")
+    except ValueError as e:
+        logger.warning(f"Caught expected error in '{check_email_potentially_failing.__name__}': {e}")
+
+    @eval(name="Simple Log Test")
+    async def simple_log_test() -> Dict[str, str]:
+        log_output = "This is a simple log test within an experiment."
+        logger.info(f"    [{simple_log_test.__name__}] {log_output}")
+        return {"log_message": log_output}
+
+    await simple_log_test()
+
+    logger.info("Finished all test cases in run_evals_experiment.")
+
+
+async def run_example() -> None:
+    print("--- Example: Experiment with Dynamically Defined and Called Evals ---")
+    try:
+        experiment_result = await run_evals_experiment()
+        print(f"--- Experiment Result from main function: {experiment_result} ---")
+    except Exception as e:
+        print(f"--- Experiment Execution FAILED: {type(e).__name__}: {e} ---")
+
+
+if __name__ == "__main__":
+    import atexit
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+    trace_provider = TracerProvider()
+    trace.set_tracer_provider(trace_provider)
+
+    console_exporter = ConsoleSpanExporter()
+    span_processor = SimpleSpanProcessor(console_exporter)
+    trace_provider.add_span_processor(span_processor)
+
+    otlp_headers = {"Authorization": f"Bearer {gentrace_api_key}"}
+
+    span_exporter = OTLPSpanExporter(
+        endpoint=f"{gentrace_base_url}/otel/v1/traces",
+        headers=otlp_headers,
+    )
+
+    span_processor = SimpleSpanProcessor(span_exporter)
+    trace_provider.add_span_processor(span_processor)
+
+    atexit.register(trace_provider.shutdown)
+
+    print("OpenTelemetry ConsoleSpanExporter initialized for basic span output.")
+
+    print("Running example...")
+
+    asyncio.run(run_example())
+
+    print("--- Example Run Finished ---")

--- a/examples/eval_dataset.py
+++ b/examples/eval_dataset.py
@@ -1,0 +1,140 @@
+"""
+This example script demonstrates how to use the Gentrace Python SDK's
+eval_dataset() feature to evaluate a function against a set of test cases.
+It showcases:
+
+- Setting up Gentrace and OpenTelemetry for tracing.
+- Defining test inputs and an interaction function.
+- Using eval_dataset() with test cases provided as a lambda, an async function,
+  and a sync function.
+
+To run this example, ensure the following environment variables are set:
+    GENTRACE_API_KEY: Your Gentrace API token for authentication.
+    GENTRACE_BASE_URL: The base URL for your Gentrace instance (e.g. https://gentrace.ai/api).
+"""
+
+import os
+import atexit
+import asyncio
+from typing import Dict, Sequence
+from typing_extensions import TypedDict
+
+from pydantic import BaseModel
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+from gentrace.types import TestCase
+from gentrace.lib.init import init
+from gentrace.lib.experiment import experiment
+from gentrace.lib.eval_dataset import TestInput, eval_dataset
+from gentrace.lib.client_handles import test_cases, test_cases_async
+
+gentrace_api_key = os.getenv("GENTRACE_API_KEY", "")
+gentrace_base_url = os.getenv("GENTRACE_BASE_URL", "")
+dataset_id = os.getenv("GENTRACE_DATASET_ID", "")
+pipeline_id = os.getenv("GENTRACE_PIPELINE_ID", "")
+
+if not gentrace_api_key:
+    raise ValueError("GENTRACE_API_KEY environment variable not set.")
+
+if not gentrace_base_url:
+    raise ValueError(
+        "GENTRACE_BASE_URL environment variable not set. Please set it to your Gentrace API endpoint (e.g., https://gentrace.ai/api)."
+    )
+
+if not dataset_id:
+    raise ValueError("GENTRACE_DATASET_ID environment variable not set.")
+
+if not pipeline_id:
+    raise ValueError("GENTRACE_PIPELINE_ID environment variable not set.")
+
+init(bearer_token=gentrace_api_key, base_url=gentrace_base_url)
+
+
+class QueryInputsSchema(BaseModel):
+    query: str
+
+
+class QueryInputs(TypedDict):
+    query: str
+
+
+def interaction(inputs: QueryInputs) -> str:
+    return f"Processed message '{inputs['query']}'"
+
+
+async def fetch_test_cases() -> Sequence[TestCase]:
+    """Fetches test cases from the specified dataset."""
+    response = await test_cases_async.list(dataset_id=dataset_id)
+    return response.data
+
+
+@experiment(pipeline_id=pipeline_id)
+async def run_my_simple_evaluation() -> None:
+    print("Starting simple dataset evaluation...")
+
+    print("Step 1: Using lambda to fetch test cases")
+    await eval_dataset(
+        data=lambda: [
+            TestInput[QueryInputs](name="Test Case 1: Welcome Message", inputs={"query": "Hello, World!"}),
+            TestInput[QueryInputs](name="Test Case 2: User Query", inputs={"query": "How does this work?"}),
+            TestInput[QueryInputs](name="Test Case 3: Empty Message (for testing)", inputs={"query": ""}),
+            TestInput[QueryInputs](name="Test Case 4: Extra Info", inputs={"query": "Test with extra"}),
+        ],
+        interaction=interaction,
+        schema=QueryInputsSchema,
+    )
+
+    print("Step 2: Using async function to fetch test cases")
+    await eval_dataset(data=fetch_test_cases, interaction=interaction, schema=QueryInputsSchema)
+
+    print("Step 3: Using sync function to fetch test cases")
+    await eval_dataset(
+        data=lambda: test_cases.list(dataset_id=dataset_id).data, interaction=interaction, schema=QueryInputsSchema
+    )
+
+    print("\nEvaluation complete. Check your Gentrace dashboard for detailed traces.")
+
+
+async def main_async_runner() -> None:
+    """Runs the main evaluation logic."""
+    await run_my_simple_evaluation()
+
+
+if __name__ == "__main__":
+    print("--- Example: eval_dataset Simple Usage ---")
+
+    # OpenTelemetry Setup
+    tracer_provider = TracerProvider()
+    trace.set_tracer_provider(tracer_provider)
+
+    otlp_headers: Dict[str, str] = {}
+
+    if gentrace_api_key:
+        otlp_headers["Authorization"] = f"Bearer {gentrace_api_key}"
+
+    span_exporter = OTLPSpanExporter(endpoint=f"{gentrace_base_url}/otel/v1/traces", headers=otlp_headers)
+
+    span_processor = SimpleSpanProcessor(span_exporter)
+    tracer_provider.add_span_processor(span_processor)
+
+    # Ensure OTel SDK is shutdown gracefully to flush traces
+    atexit.register(tracer_provider.shutdown)
+    print("OpenTelemetry OTLPSpanExporter initialized and SDK shutdown handler registered.")
+
+    print("Running example...")
+
+    try:
+        asyncio.run(main_async_runner())
+    except RuntimeError as e:
+        if "cannot be called from a running event loop" in str(e):
+            # This can happen if running in an environment like Jupyter
+            # where an event loop is already running.
+            loop = asyncio.get_running_loop()
+            loop.create_task(main_async_runner())
+        else:
+            raise
+
+    print("--- Example Run Finished ---")

--- a/examples/test_cases.py
+++ b/examples/test_cases.py
@@ -35,7 +35,7 @@ async def main() -> None:
 
     response = await test_cases_async.list(dataset_id=dataset_id)
     for test_case in response.data:
-        print(f"ID: {test_case.id}, Name: {test_case.name}")
+        print(test_case.inputs)
 
 
 if __name__ == "__main__":

--- a/src/gentrace/__init__.py
+++ b/src/gentrace/__init__.py
@@ -52,13 +52,31 @@ from .lib.client_instance import _get_sync_client_instance, _get_async_client_in
 
 
 class _ResourceWrapper:
+    """A wrapper class that provides lazy access to Gentrace API resources.
+
+    This class acts as a proxy to access resources (like pipelines, experiments, etc.) from
+    either a synchronous or asynchronous Gentrace client. It lazily initializes the client
+    only when a resource method is actually accessed.
+
+    Args:
+        client_accessor_func: A callable that returns either a Gentrace or AsyncGentrace client instance
+        resource_name: The name of the resource to wrap (e.g. "pipelines", "experiments")
+    """
+
     def __init__(self, client_accessor_func: Callable[[], Union[Gentrace, AsyncGentrace]], resource_name: str):
         """Initializes the resource wrapper."""
         self._client_accessor_func = client_accessor_func
         self._resource_name = resource_name
 
     def __getattr__(self, name: str) -> Any:
-        """Gets an attribute from the underlying resource."""
+        """Gets an attribute from the underlying resource.
+
+        Args:
+            name: The name of the attribute to access on the resource
+
+        Returns:
+            The requested attribute from the underlying resource
+        """
         client = self._client_accessor_func()
         resource_obj = getattr(client, self._resource_name)
         return getattr(resource_obj, name)
@@ -74,10 +92,14 @@ experiments_async = cast(AsyncExperimentsResource, _ResourceWrapper(_get_async_c
 datasets_async = cast(AsyncDatasetsResource, _ResourceWrapper(_get_async_client_instance, "datasets"))
 test_cases_async = cast(AsyncTestCasesResource, _ResourceWrapper(_get_async_client_instance, "test_cases"))
 
+from .lib.eval import eval
 from .lib.init import init
 from .lib.traced import traced
 from .lib.experiment import experiment
 from .lib.interaction import interaction
+from .lib.eval_dataset import TestInput, eval_dataset
+
+### End custom Gentrace imports
 
 __all__ = [
     "types",
@@ -118,12 +140,15 @@ __all__ = [
     "DEFAULT_CONNECTION_LIMITS",
     "DefaultHttpxClient",
     "DefaultAsyncHttpxClient",
-
     # Start custom Gentrace exports
     "init",
     "traced",
     "interaction",
     "experiment",
+    "eval",
+    "eval_dataset",
+    "TestInput",
+    # End custom Gentrace exports
 ]
 
 _setup_logging()

--- a/src/gentrace/__init__.py
+++ b/src/gentrace/__init__.py
@@ -76,6 +76,7 @@ test_cases_async = cast(AsyncTestCasesResource, _ResourceWrapper(_get_async_clie
 
 from .lib.init import init
 from .lib.traced import traced
+from .lib.experiment import experiment
 from .lib.interaction import interaction
 
 __all__ = [
@@ -118,10 +119,11 @@ __all__ = [
     "DefaultHttpxClient",
     "DefaultAsyncHttpxClient",
 
-    # Custom library functions
+    # Start custom Gentrace exports
     "init",
     "traced",
     "interaction",
+    "experiment",
 ]
 
 _setup_logging()

--- a/src/gentrace/lib/client_handles.py
+++ b/src/gentrace/lib/client_handles.py
@@ -1,0 +1,50 @@
+from typing import Any, Union, Callable, cast
+
+from gentrace import Gentrace, AsyncGentrace
+from gentrace.resources import (
+    DatasetsResource,
+    PipelinesResource,
+    TestCasesResource,
+    ExperimentsResource,
+    AsyncDatasetsResource,
+    AsyncPipelinesResource,
+    AsyncTestCasesResource,
+    AsyncExperimentsResource,
+)
+
+from .client_instance import _get_sync_client_instance, _get_async_client_instance
+
+
+class _ResourceWrapper:
+    def __init__(self, client_accessor_func: Callable[[], Union[Gentrace, AsyncGentrace]], resource_name: str):
+        """Initializes the resource wrapper."""
+        self._client_accessor_func = client_accessor_func
+        self._resource_name = resource_name
+
+    def __getattr__(self, name: str) -> Any:
+        """Gets an attribute from the underlying resource."""
+        client = self._client_accessor_func()
+        resource_obj = getattr(client, self._resource_name)
+        return getattr(resource_obj, name)
+
+
+pipelines = cast(PipelinesResource, _ResourceWrapper(_get_sync_client_instance, "pipelines"))
+experiments = cast(ExperimentsResource, _ResourceWrapper(_get_sync_client_instance, "experiments"))
+datasets = cast(DatasetsResource, _ResourceWrapper(_get_sync_client_instance, "datasets"))
+test_cases = cast(TestCasesResource, _ResourceWrapper(_get_sync_client_instance, "test_cases"))
+
+pipelines_async = cast(AsyncPipelinesResource, _ResourceWrapper(_get_async_client_instance, "pipelines"))
+experiments_async = cast(AsyncExperimentsResource, _ResourceWrapper(_get_async_client_instance, "experiments"))
+datasets_async = cast(AsyncDatasetsResource, _ResourceWrapper(_get_async_client_instance, "datasets"))
+test_cases_async = cast(AsyncTestCasesResource, _ResourceWrapper(_get_async_client_instance, "test_cases"))
+
+__all__ = [
+    "pipelines",
+    "experiments",
+    "datasets",
+    "test_cases",
+    "pipelines_async",
+    "experiments_async",
+    "datasets_async",
+    "test_cases_async",
+]

--- a/src/gentrace/lib/eval.py
+++ b/src/gentrace/lib/eval.py
@@ -1,0 +1,137 @@
+import inspect
+import logging
+import functools
+from typing import Any, Dict, TypeVar, Callable, Optional, Coroutine, overload
+from typing_extensions import ParamSpec
+
+from opentelemetry import trace
+from opentelemetry.trace.status import Status, StatusCode
+
+from .utils import _gentrace_json_dumps  # For safe serialization of output
+from .constants import ANONYMOUS_SPAN_NAME
+from .experiment import ExperimentContext, register_eval_function, get_current_experiment_context
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+_tracer = trace.get_tracer("gentrace.sdk")
+logger = logging.getLogger("gentrace")
+
+RESERVED_METADATA_KEYS = {
+    "gentrace.experiment_id",
+    "gentrace.test_case_name",
+    "gentrace.fn.args",
+    "gentrace.fn.output",
+}
+
+@overload
+def eval(
+    *,
+    name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Callable[[Callable[P, Coroutine[Any, Any, R]]], Callable[P, Coroutine[Any, Any, R]]]:
+    ...
+
+@overload
+def eval(
+    *,
+    name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Callable[[Callable[P, R]], Callable[P, Coroutine[Any, Any, R]]]: # Sync func becomes awaitable
+    ...
+
+def eval(
+    *,
+    name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Callable[[Callable[P, Any]], Callable[P, Coroutine[Any, Any, Any]]]:
+    """
+    Decorator factory to mark a function as a single evaluation test case within an experiment.
+
+    This decorator must be used on a function that is called within the scope of an
+    `@experiment()` decorated function.
+
+    When the decorated function is called:
+    1. It retrieves the current `experiment_id` and `pipeline_id` from the context
+       set by `@experiment()`.
+    2. It creates an OpenTelemetry span representing this specific evaluation.
+       The span is named using the provided `name` argument.
+    3. Attributes `gentrace.experiment_id` and `gentrace.test_case_name` are set on the span.
+    4. Any provided `metadata` is added to the span.
+    5. The decorated function's execution (inputs, output, errors) is captured within this span:
+       - Input arguments are logged as a 'gentrace.fn.args' event with an 'args' key
+       - Function output is logged as a 'gentrace.fn.output' event with an 'output' key
+    6. If the decorated function is synchronous, it is wrapped to be awaitable, fitting into
+       the common asynchronous flow of experiment execution.
+
+    Args:
+        name: A descriptive name for this evaluation test case. This will be used as part
+              of the OTEL span name and as an attribute.
+        metadata: Optional dictionary of arbitrary metadata to attach to this evaluation's span.
+
+    Returns:
+        A decorator that wraps the user's function.
+    """
+    def inner_decorator(func: Callable[P, Any]) -> Callable[P, Coroutine[Any, Any, Any]]:
+        @functools.wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+            experiment_context: Optional[ExperimentContext] = get_current_experiment_context()
+
+            if not experiment_context:
+                func_name = getattr(func, '__name__', ANONYMOUS_SPAN_NAME)
+                raise RuntimeError(
+                    f"@eval(name='{name}') on function '{func_name}' must be called within an active @experiment context."
+                )
+
+            span_name = f"Eval: {name}"
+            
+            with _tracer.start_as_current_span(span_name) as span:
+                span.set_attribute("gentrace.experiment_id", experiment_context["experiment_id"])
+                span.set_attribute("gentrace.test_case_name", span_name)
+
+                if metadata:
+                    for key, value in metadata.items():
+                        if key in RESERVED_METADATA_KEYS:
+                            logger.warning(
+                                f"Metadata key `{key}` is reserved and will be ignored for @eval test case `{name}`. Avoid using reserved keys for metadata."
+                            )
+                            continue
+                        try:
+                            if isinstance(value, (dict, list, tuple)):
+                                span.set_attribute(key, _gentrace_json_dumps(value))
+                            elif value is not None:
+                                span.set_attribute(key, str(value))
+                        except Exception:
+                            span.set_attribute(key, f"[Unserializable metadata: {key}]")
+                
+                if args or kwargs:
+                    input_payload: Dict[str, Any] = {}
+                    if args:
+                        input_payload["args"] = args
+                    if kwargs:
+                        input_payload["kwargs"] = kwargs
+                    span.add_event("gentrace.fn.args", {"args": _gentrace_json_dumps(input_payload)})
+
+
+                try:
+                    if inspect.iscoroutinefunction(func):
+                        result = await func(*args, **kwargs)
+                    else:
+                        result = func(*args, **kwargs)
+                    
+                    span.add_event("gentrace.fn.output", {"output": _gentrace_json_dumps(result)})
+                    return result
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(Status(StatusCode.ERROR, description=str(e)))
+                    span.set_attribute("error.type", e.__class__.__name__)
+                    raise
+        
+        # Register the OpenTelemetry-instrumented wrapper for auto-execution
+        # by the @experiment decorator.
+        register_eval_function(wrapper)
+        
+        return wrapper
+    return inner_decorator
+
+__all__ = ["eval"] 

--- a/src/gentrace/lib/eval_dataset.py
+++ b/src/gentrace/lib/eval_dataset.py
@@ -1,0 +1,283 @@
+import asyncio
+import inspect
+import logging
+from typing import (
+    Any,
+    Dict,
+    List,
+    Type,
+    Union,
+    Generic,
+    Mapping,
+    TypeVar,
+    Callable,
+    Optional,
+    Sequence,
+    Awaitable,
+    cast,
+)
+from typing_extensions import Protocol, TypeAlias, TypedDict, overload
+
+from pydantic import BaseModel, ValidationError
+from opentelemetry import trace
+from opentelemetry.trace.status import Status, StatusCode
+
+from gentrace.types.test_case import TestCase
+
+from .utils import is_pydantic_v1, _gentrace_json_dumps
+from .experiment import ExperimentContext, get_current_experiment_context
+
+logger = logging.getLogger("gentrace")
+
+# Type Variables for eval_dataset
+InputPayload = TypeVar("InputPayload", bound=Mapping[str, Any])  # Type of the raw inputs within a TestCase
+TInput = TypeVar("TInput")           # Type of the (potentially parsed) input to interaction fn
+TResult = TypeVar("TResult")         # Return type of the interaction fn
+SchemaPydanticModel = TypeVar("SchemaPydanticModel", bound=BaseModel) # Type for Pydantic schema
+
+_tracer = trace.get_tracer("gentrace.sdk")
+
+class TestInputProtocol(Protocol, Generic[InputPayload]):
+    id: Optional[str]
+    name: Optional[str]
+    inputs: InputPayload
+
+    def __getitem__(self, key: str) -> Any:
+        ...
+
+class TestInput(TypedDict, Generic[InputPayload], total=False):
+    name: str
+    inputs: InputPayload
+
+DataProviderType: TypeAlias = Callable[
+    [],
+    Union[
+        Awaitable[Sequence[Union[TestCase, TestInput[InputPayload]]]],
+        Sequence[Union[TestCase, TestInput[InputPayload]]]
+    ]
+]
+
+async def _run_single_test_case_for_dataset(
+    test_case_name: str,
+    test_case_id: Optional[str],
+    raw_inputs: Optional[InputPayload],
+    interaction_function: Callable[[Optional[TInput]], Union[TResult, Awaitable[TResult]]],
+    input_schema: Optional[Type[BaseModel]],
+    experiment_context: ExperimentContext,
+) -> Optional[TResult]:
+    """
+    Internal helper to run and trace a single test case from a dataset.
+    This is similar to the logic in the @eval decorator but adapted for dataset items.
+    """
+    span_name = test_case_name
+    span_event_attributes: Dict[str, str] = {}
+    result_value: Any = None  # type: ignore
+
+    with _tracer.start_as_current_span(span_name) as span:
+        span.set_attribute("gentrace.experiment_id", experiment_context["experiment_id"])
+        span.set_attribute("gentrace.test_case.name", test_case_name)
+        if test_case_id:
+            span.set_attribute("gentrace.test_case.id", test_case_id)
+
+        try:
+            # Always pass the raw dict (or None) into the interaction fn
+            parsed_input_for_interaction: Optional[TInput] = raw_inputs  # type: ignore
+            input_dict_for_log: Any = None
+
+            if input_schema:
+                # Validate against Pydantic but do *not* pass the model instance downstream
+                model_schema = input_schema
+                try:
+                    if is_pydantic_v1():
+                        validated = model_schema.parse_obj(raw_inputs) # type: ignore
+                    else:
+                        validated = model_schema.model_validate(raw_inputs)
+
+                    # Log the dictified validated model
+                    if hasattr(validated, "model_dump"):
+                        input_dict_for_log = validated.model_dump()
+                    elif hasattr(validated, "dict"):
+                        input_dict_for_log = validated.dict() # type: ignore
+                    else:
+                        input_dict_for_log = validated
+
+                    span_event_attributes["inputs_validated"] = _gentrace_json_dumps(input_dict_for_log)
+                except ValidationError as ve:
+                    logger.error(
+                        f"Pydantic validation failed for test case {test_case_name}. Inputs: {raw_inputs}",
+                        exc_info=True,
+                    )
+                    span.record_exception(ve)
+                    span.set_status(Status(StatusCode.ERROR, description="Input validation failed"))
+                    span.set_attribute("error.type", ve.__class__.__name__)
+                    return None
+
+            elif raw_inputs is not None:
+                # No schema → just log the raw dict
+                input_dict_for_log = raw_inputs
+                span_event_attributes["inputs_raw"] = _gentrace_json_dumps(input_dict_for_log)
+            else:
+                # both schema is None and raw_inputs is None
+                input_dict_for_log = None
+
+            # Attach the inputs as a span event
+            if input_dict_for_log is not None:
+                span.add_event(
+                    "gentrace.fn.args",
+                    {"args": _gentrace_json_dumps([input_dict_for_log])},
+                )
+
+            # Call the interaction function with the original dict (or None)
+            if inspect.iscoroutinefunction(interaction_function):
+                result_value = await interaction_function(parsed_input_for_interaction)
+            else:
+                result_value = interaction_function(parsed_input_for_interaction)
+
+            # Log the output
+            span.add_event("gentrace.fn.output", {"output": _gentrace_json_dumps(result_value)})
+            return cast(Optional[TResult], result_value)
+
+        except Exception as e:
+            logger.error(
+                f"Unknown error occurred while running test case {test_case_name}",
+                exc_info=True,
+            )
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, description=str(e)))
+            span.set_attribute("error.type", e.__class__.__name__)
+            return None
+
+
+@overload
+async def eval_dataset(
+    *,
+    data: DataProviderType[InputPayload],
+    schema: Type[SchemaPydanticModel],
+    interaction: Callable[[InputPayload], TResult],
+) -> Sequence[Optional[TResult]]:
+    ...
+
+@overload
+async def eval_dataset(
+    *,
+    data: DataProviderType[InputPayload],
+    schema: Type[SchemaPydanticModel],
+    interaction: Callable[[InputPayload], Awaitable[TResult]],
+) -> Sequence[Optional[TResult]]:
+    ...
+
+@overload
+async def eval_dataset(
+    *,
+    data: DataProviderType[InputPayload],
+    interaction: Callable[[InputPayload], TResult],
+) -> Sequence[Optional[TResult]]:
+    ...
+
+@overload
+async def eval_dataset(
+    *,
+    data: DataProviderType[InputPayload],
+    interaction: Callable[[InputPayload], Awaitable[TResult]],
+) -> Sequence[Optional[TResult]]:
+    ...
+
+async def eval_dataset(
+    *,
+    data: DataProviderType[InputPayload],
+    schema: Optional[Type[SchemaPydanticModel]] = None,
+    interaction: Callable[[Any], Union[TResult, Awaitable[TResult]]],
+) -> Sequence[Optional[TResult]]:
+    """
+    Runs a series of test cases from a dataset against a specified interaction function,
+    all within an active Gentrace experiment context.
+
+    This function must be called within a function decorated by `@experiment()`.
+    Each test case execution is traced as an individual OpenTelemetry span, tagged with
+    details from the experiment context and the test case itself.
+
+    Args:
+        data (Callable): A function or coroutine function that returns a list of TestInputs.
+                         Each TestInput should be a dictionary-like object with an `inputs`
+                         key, and optional `id`, `name` keys. Can be either TestInputProtocol
+                         or TestInput[InputPayload].
+        schema (Optional[Type[pydantic.BaseModel]]): A Pydantic model to validate the `inputs`
+                                                   of each TestInput. If validation fails for a
+                                                   case, an error is logged to its span, and
+                                                   the exception is raised (halting that specific case).
+        interaction (Callable): The function to test for each test case.
+                               Receives (optionally validated) inputs.
+
+    Returns:
+        A list containing the results of the `interaction` function for each successfully
+        processed test case. Failed test cases (e.g. due to input validation errors)
+        will have a corresponding `None` value in the list.
+
+    Raises:
+        RuntimeError: If called outside of an active `@experiment` context or if the
+                      `data` provider fails catastrophically.
+        Any exception raised during a specific test case interaction (after validation)
+        will propagate from that specific test case run.
+    """
+    experiment_context = get_current_experiment_context()
+    if not experiment_context:
+        raise RuntimeError(
+            "eval_dataset must be called within the context of an @experiment() decorated function."
+        )
+
+    interaction_fn = interaction
+    data_provider = data
+    input_schema = schema
+
+    raw_test_cases: Sequence[Union[TestCase, TestInput[InputPayload]]]
+    try:
+        data_result = data_provider()
+        if inspect.isawaitable(data_result):
+            raw_test_cases = await data_result
+        else:
+            raw_test_cases = data_result
+    except Exception as e:
+        # Potentially log this with a Gentrace SDK logger if available
+        raise RuntimeError(
+            f"Failed to retrieve or process dataset from data provider: {e}"
+        ) from e
+
+    evaluation_tasks: List[Awaitable[Optional[TResult]]] = []
+    for i, test_case in enumerate(raw_test_cases):
+        case_inputs: Optional[InputPayload]
+        case_id: Optional[str]
+        case_name_prop: Optional[str]
+
+        if isinstance(test_case, dict):
+            # TypedDict case
+            case_inputs = test_case.get("inputs")
+            case_id = None
+            case_name_prop = test_case.get("name")
+        else:
+            protocol_case = test_case
+            case_inputs = cast(InputPayload, protocol_case.inputs)
+            case_id = protocol_case.id 
+            case_name_prop = protocol_case.name
+
+        final_case_name: str
+        if case_name_prop:
+            final_case_name = case_name_prop
+        elif case_id:
+            final_case_name = f"Test Case (ID: {case_id})"
+        else:
+            final_case_name = f"Test Case {i + 1}"
+        
+        task = _run_single_test_case_for_dataset(
+            test_case_name=final_case_name,
+            test_case_id=case_id,
+            raw_inputs=case_inputs,
+            interaction_function=interaction_fn,
+            input_schema=input_schema,
+            experiment_context=experiment_context,
+        )
+        evaluation_tasks.append(task)
+
+    results = await asyncio.gather(*evaluation_tasks, return_exceptions=False)
+    return results
+
+__all__ = ["eval_dataset", "TestInput"] 

--- a/src/gentrace/lib/experiment.py
+++ b/src/gentrace/lib/experiment.py
@@ -1,8 +1,9 @@
+import uuid
 import inspect
 import logging
 import functools
 import contextvars
-from typing import Any, Dict, List, TypeVar, Callable, Optional, Coroutine
+from typing import Any, Dict, Union, TypeVar, Callable, Optional, Awaitable, Coroutine
 from typing_extensions import ParamSpec, TypedDict
 
 from .experiment_control import start_experiment_api, finish_experiment_api
@@ -12,25 +13,26 @@ R = TypeVar("R")
 
 logger = logging.getLogger("gentrace")
 
+
 class ExperimentContext(TypedDict):
     """
     Represents the context for an experiment run. This context is stored in
     a ContextVar to make the experiment ID and pipeline ID available throughout
     the asynchronous execution flow.
     """
+
     experiment_id: str
     pipeline_id: str
 
-experiment_context_var: contextvars.ContextVar[Optional[ExperimentContext]] = \
-    contextvars.ContextVar("gentrace_experiment_context", default=None)
 
-# Context variable to hold the list of eval functions registered for the current experiment
-_experiment_eval_functions_var: contextvars.ContextVar[Optional[List[Callable[[], Any]]]] = \
-    contextvars.ContextVar("gentrace_experiment_eval_functions", default=None)
+experiment_context_var: contextvars.ContextVar[Optional[ExperimentContext]] = contextvars.ContextVar(
+    "gentrace_experiment_context", default=None
+)
+
 
 def get_current_experiment_context() -> Optional[ExperimentContext]:
     """
-    Retrieves the ExperimentContext (experiment_id, pipeline_id) from the 
+    Retrieves the ExperimentContext (experiment_id, pipeline_id) from the
     current asynchronous context, if an experiment is active.
 
     Returns:
@@ -38,37 +40,28 @@ def get_current_experiment_context() -> Optional[ExperimentContext]:
     """
     return experiment_context_var.get()
 
-def register_eval_function(func: Callable[[], Any]) -> None:
-    """
-    Registers an evaluation function to be run by the current experiment.
-    This function is intended to be called by an @eval decorator.
-    """
-    registry = _experiment_eval_functions_var.get()
-    if registry is None:
-        # This might happen if @eval is used outside an @experiment.
-        # Depending on desired strictness, this could raise an error or log a warning.
-        logger.warning(
-            f"The @eval decorator was used on function `{getattr(func, '__name__', 'unknown')}` "
-            f"outside of an active @experiment context. This @eval function will not be automatically executed. Ensure @eval is called within an @experiment decorated function."
-        )
-        return
-    registry.append(func)
 
 class ExperimentOptions(TypedDict, total=False):
-    """ Optional parameters for running an experiment. """
-    name: Optional[str] 
+    """Optional parameters for running an experiment."""
+
+    name: Optional[str]
     """Optional name for the experiment run. This will be used as the name for the root OpenTelemetry span."""
-    metadata: Optional[Dict[str, Any]] 
+    metadata: Optional[Dict[str, Any]]
     """User-defined metadata for the experiment. This will be added as attributes to the root OpenTelemetry span."""
 
+
 def experiment(
-    *, 
+    *,
     pipeline_id: str,
     options: Optional[ExperimentOptions] = None,
-) -> Callable[[Callable[P, Any]], Callable[P, Coroutine[Any, Any, Any]]]:
+) -> Callable[[Callable[P, Any]], Callable[P, Coroutine[Any, Any, None]]]:
     """
     A decorator factory that wraps a function to manage a Gentrace Experiment lifecycle.
-    This is the primary way to define a scope for running evaluations.
+    This is the primary way to define a scope for running evaluations. The decorated
+    function itself should not have a meaningful return value (i.e., it should be
+    annotated as `-> None` or omit its return type if it implicitly returns None),
+    as its return value will be ignored by this decorator. The call to the
+    decorated function will always resolve to `None`.
 
     When a function is decorated with `@experiment`:
     1.  A new Gentrace Experiment run is started by calling the Gentrace API. The optional
@@ -77,20 +70,25 @@ def experiment(
         asynchronous context variable. This context is accessible via
         `get_current_experiment_context()` within the decorated function.
     3.  The primary use of this decorated function is to serve as a context for calling
-        evaluation utilities like `eval()` and `eval_dataset()`. These utilities,
-        when called within the decorated function, will:
+        evaluation functions (e.g., those decorated with `@eval`) or other tracing utilities
+        like `eval_dataset()`. These utilities, when called within the decorated function, will:
         a.  Access the `experiment_id` and `pipeline_id` from the context.
         b.  Typically create their own OpenTelemetry spans for individual test cases or
             evaluations, tagging these spans with the `experiment_id`.
             (Note: This `@experiment` decorator itself does NOT create an overarching
             OpenTelemetry span for the entire experiment function. OTEL span creation
-            is deferred to the evaluation utilities like `eval` or functions
+            is deferred to the evaluation utilities or functions
             decorated with `@traced` called within this experiment context).
     4.  If the decorated function is synchronous, it will be run in a way that integrates
         with the surrounding asynchronous operations, and the decorated function will
         become awaitable.
     5.  Upon completion or error of the decorated function, the Gentrace Experiment run is
         finalized via an API call to Gentrace.
+    6.  Any value returned by the decorated function is ignored. The decorated function,
+        when called, will always result in `None`. Users should annotate their
+        experiment functions with `-> None` or omit the return type if it implicitly
+        returns `None`. Type checkers will likely warn if the decorated function
+        is annotated to return any other type.
 
     Args:
         pipeline_id: The ID of the pipeline to associate with this experiment.
@@ -102,32 +100,58 @@ def experiment(
 
     Returns:
         A decorator that wraps the user's function, transforming it into an awaitable
-        that executes the experiment lifecycle logic.
+        that executes the experiment lifecycle logic and always resolves to `None`.
 
     Usage Example:
         ```python
         from gentrace import experiment, eval, compose_email
+        import asyncio
 
-        @experiment(pipeline_id="<uuid>")
-        async def email_evals():
 
-            @eval
-            def should_include_hello(message: str) -> str:
+        @experiment(pipeline_id="<your-pipeline-id>")
+        async def email_evals_experiment():
+            @eval(name="check_subject_and_body_1")
+            async def check_email_content_1(subject_to_check: str, body_to_check: str):
                 email = compose_email(
-                    subject="Hello",
-                    body="Hello, how are you?",
+                    subject=subject_to_check,
+                    body=body_to_check,
                     to="test@example.com",
                     from_="test@example.com",
                 )
-
-                assert "Hello" in email
+                assert subject_to_check in email
+                assert body_to_check in email
                 return email
-            
-        asyncio.run(email_evals())
+
+            # Invoke the @eval decorated function immediately after definition
+            await check_email_content_1(subject_to_check="Hello Test", body_to_check="This is a test email.")
+
+            @eval(name="check_subject_and_body_2")
+            async def check_email_content_2(subject_to_check: str, body_to_check: str):
+                email = compose_email(
+                    subject=subject_to_check,
+                    body=body_to_check,
+                    to="test@example.com",
+                    from_="test@example.com",
+                )
+                assert subject_to_check in email
+                assert body_to_check in email
+                return email
+
+            # Invoke again, perhaps with different params or as a separate test case
+            await check_email_content_2(subject_to_check="Another Subject", body_to_check="Another body.")
+
+
+        # To run the experiment:
+        # asyncio.run(email_evals_experiment())
         ```
     """
 
-    def inner_decorator(func: Callable[P, Any]) -> Callable[P, Coroutine[Any, Any, Any]]:
+    try:
+        uuid.UUID(pipeline_id)
+    except ValueError as e:
+        raise ValueError(f"Invalid pipeline_id: '{pipeline_id}'. Must be a valid UUID.") from e
+
+    def inner_decorator(func: Callable[P, Union[None, Awaitable[None]]]) -> Callable[P, Coroutine[Any, Any, None]]:
         @functools.wraps(func)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
             exp_name_option = options.get("name") if options else None
@@ -149,47 +173,26 @@ def experiment(
                 "experiment_id": experiment_id_val,
                 "pipeline_id": pipeline_id,
             }
-            
+
             token = experiment_context_var.set(context_data)
-            
-            result: Optional[Any] = None
-            current_eval_functions: List[Callable[[], Any]] = []
-            eval_registry_token: Optional[contextvars.Token[Optional[List[Callable[[], Any]]]]] = None
 
             try:
-                # Set up the registry for @eval functions defined within this experiment
-                eval_registry_token = _experiment_eval_functions_var.set(current_eval_functions)
-
                 if inspect.iscoroutinefunction(func):
-                    result = await func(*args, **kwargs)
+                    await func(*args, **kwargs)
                 else:
-                    result = func(*args, **kwargs)
-                
-                # After the main function has run, execute registered @eval functions
-                if current_eval_functions:
-                    logger.debug(f"Experiment `{exp_name_option or pipeline_id}`: Executing {len(current_eval_functions)} registered @eval function(s).")
-                    for i, eval_func in enumerate(current_eval_functions):
-                        eval_name = getattr(eval_func, '__name__', f'eval_function_{i+1}')
-                        try:
-                            logger.debug(f"Executing @eval function: `{eval_name}`.")
-                            if inspect.iscoroutinefunction(eval_func):
-                                await eval_func()
-                            else:
-                                eval_func()
-                            logger.debug(f"@eval function `{eval_name}` completed successfully.")
-                        except AssertionError as e:
-                            logger.error(f"@eval function `{eval_name}` failed with an AssertionError. Details: {e}")
-                        except Exception as e:
-                            logger.error(f"@eval function `{eval_name}` encountered an unexpected error. Details: {e}")
+                    func(*args, **kwargs)
+
             finally:
-                if eval_registry_token:
-                    _experiment_eval_functions_var.reset(eval_registry_token)
                 experiment_context_var.reset(token)
                 if experiment_id_val:
                     await finish_experiment_api(id=experiment_id_val)
-            
-            return result
+
+            # Return the result of the decorated function
+            return None
+
         return wrapper
+
     return inner_decorator
 
-__all__ = ["experiment", "get_current_experiment_context", "ExperimentContext", "ExperimentOptions", "register_eval_function"] 
+
+__all__ = ["experiment", "get_current_experiment_context", "ExperimentContext", "ExperimentOptions"]

--- a/src/gentrace/lib/experiment.py
+++ b/src/gentrace/lib/experiment.py
@@ -1,0 +1,195 @@
+import inspect
+import logging
+import functools
+import contextvars
+from typing import Any, Dict, List, TypeVar, Callable, Optional, Coroutine
+from typing_extensions import ParamSpec, TypedDict
+
+from .experiment_control import start_experiment_api, finish_experiment_api
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+logger = logging.getLogger("gentrace")
+
+class ExperimentContext(TypedDict):
+    """
+    Represents the context for an experiment run. This context is stored in
+    a ContextVar to make the experiment ID and pipeline ID available throughout
+    the asynchronous execution flow.
+    """
+    experiment_id: str
+    pipeline_id: str
+
+experiment_context_var: contextvars.ContextVar[Optional[ExperimentContext]] = \
+    contextvars.ContextVar("gentrace_experiment_context", default=None)
+
+# Context variable to hold the list of eval functions registered for the current experiment
+_experiment_eval_functions_var: contextvars.ContextVar[Optional[List[Callable[[], Any]]]] = \
+    contextvars.ContextVar("gentrace_experiment_eval_functions", default=None)
+
+def get_current_experiment_context() -> Optional[ExperimentContext]:
+    """
+    Retrieves the ExperimentContext (experiment_id, pipeline_id) from the 
+    current asynchronous context, if an experiment is active.
+
+    Returns:
+        The current ExperimentContext or None if not within an experiment() context.
+    """
+    return experiment_context_var.get()
+
+def register_eval_function(func: Callable[[], Any]) -> None:
+    """
+    Registers an evaluation function to be run by the current experiment.
+    This function is intended to be called by an @eval decorator.
+    """
+    registry = _experiment_eval_functions_var.get()
+    if registry is None:
+        # This might happen if @eval is used outside an @experiment.
+        # Depending on desired strictness, this could raise an error or log a warning.
+        logger.warning(
+            f"The @eval decorator was used on function `{getattr(func, '__name__', 'unknown')}` "
+            f"outside of an active @experiment context. This @eval function will not be automatically executed. Ensure @eval is called within an @experiment decorated function."
+        )
+        return
+    registry.append(func)
+
+class ExperimentOptions(TypedDict, total=False):
+    """ Optional parameters for running an experiment. """
+    name: Optional[str] 
+    """Optional name for the experiment run. This will be used as the name for the root OpenTelemetry span."""
+    metadata: Optional[Dict[str, Any]] 
+    """User-defined metadata for the experiment. This will be added as attributes to the root OpenTelemetry span."""
+
+def experiment(
+    *, 
+    pipeline_id: str,
+    options: Optional[ExperimentOptions] = None,
+) -> Callable[[Callable[P, Any]], Callable[P, Coroutine[Any, Any, Any]]]:
+    """
+    A decorator factory that wraps a function to manage a Gentrace Experiment lifecycle.
+    This is the primary way to define a scope for running evaluations.
+
+    When a function is decorated with `@experiment`:
+    1.  A new Gentrace Experiment run is started by calling the Gentrace API. The optional
+        `name` and `metadata` from `options` are passed to this API call.
+    2.  The `experiment_id` (obtained from the API) and `pipeline_id` are stored in an
+        asynchronous context variable. This context is accessible via
+        `get_current_experiment_context()` within the decorated function.
+    3.  The primary use of this decorated function is to serve as a context for calling
+        evaluation utilities like `eval()` and `eval_dataset()`. These utilities,
+        when called within the decorated function, will:
+        a.  Access the `experiment_id` and `pipeline_id` from the context.
+        b.  Typically create their own OpenTelemetry spans for individual test cases or
+            evaluations, tagging these spans with the `experiment_id`.
+            (Note: This `@experiment` decorator itself does NOT create an overarching
+            OpenTelemetry span for the entire experiment function. OTEL span creation
+            is deferred to the evaluation utilities like `eval` or functions
+            decorated with `@traced` called within this experiment context).
+    4.  If the decorated function is synchronous, it will be run in a way that integrates
+        with the surrounding asynchronous operations, and the decorated function will
+        become awaitable.
+    5.  Upon completion or error of the decorated function, the Gentrace Experiment run is
+        finalized via an API call to Gentrace.
+
+    Args:
+        pipeline_id: The ID of the pipeline to associate with this experiment.
+        options: Optional parameters for the Gentrace Experiment entity:
+            name (Optional[str]): A name for the Gentrace Experiment. This is passed to the
+                                  Gentrace API.
+            metadata (Optional[Dict[str, Any]]): User-defined metadata for the Gentrace Experiment.
+                                               Passed to the Gentrace API.
+
+    Returns:
+        A decorator that wraps the user's function, transforming it into an awaitable
+        that executes the experiment lifecycle logic.
+
+    Usage Example:
+        ```python
+        from gentrace import experiment, eval, compose_email
+
+        @experiment(pipeline_id="<uuid>")
+        async def email_evals():
+
+            @eval
+            def should_include_hello(message: str) -> str:
+                email = compose_email(
+                    subject="Hello",
+                    body="Hello, how are you?",
+                    to="test@example.com",
+                    from_="test@example.com",
+                )
+
+                assert "Hello" in email
+                return email
+            
+        asyncio.run(email_evals())
+        ```
+    """
+
+    def inner_decorator(func: Callable[P, Any]) -> Callable[P, Coroutine[Any, Any, Any]]:
+        @functools.wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+            exp_name_option = options.get("name") if options else None
+            user_metadata = options.get("metadata") if options else None
+
+            experiment_id_val: Optional[str] = None
+            try:
+                experiment_id_val = await start_experiment_api(
+                    pipelineId=pipeline_id, name=exp_name_option, metadata=user_metadata
+                )
+            except Exception as e:
+                logger.error(f"Failed to start Gentrace experiment via API. Details: {e}")
+                raise
+
+            if not experiment_id_val:
+                raise RuntimeError("Failed to obtain experiment_id from API.")
+
+            context_data: ExperimentContext = {
+                "experiment_id": experiment_id_val,
+                "pipeline_id": pipeline_id,
+            }
+            
+            token = experiment_context_var.set(context_data)
+            
+            result: Optional[Any] = None
+            current_eval_functions: List[Callable[[], Any]] = []
+            eval_registry_token: Optional[contextvars.Token[Optional[List[Callable[[], Any]]]]] = None
+
+            try:
+                # Set up the registry for @eval functions defined within this experiment
+                eval_registry_token = _experiment_eval_functions_var.set(current_eval_functions)
+
+                if inspect.iscoroutinefunction(func):
+                    result = await func(*args, **kwargs)
+                else:
+                    result = func(*args, **kwargs)
+                
+                # After the main function has run, execute registered @eval functions
+                if current_eval_functions:
+                    logger.debug(f"Experiment `{exp_name_option or pipeline_id}`: Executing {len(current_eval_functions)} registered @eval function(s).")
+                    for i, eval_func in enumerate(current_eval_functions):
+                        eval_name = getattr(eval_func, '__name__', f'eval_function_{i+1}')
+                        try:
+                            logger.debug(f"Executing @eval function: `{eval_name}`.")
+                            if inspect.iscoroutinefunction(eval_func):
+                                await eval_func()
+                            else:
+                                eval_func()
+                            logger.debug(f"@eval function `{eval_name}` completed successfully.")
+                        except AssertionError as e:
+                            logger.error(f"@eval function `{eval_name}` failed with an AssertionError. Details: {e}")
+                        except Exception as e:
+                            logger.error(f"@eval function `{eval_name}` encountered an unexpected error. Details: {e}")
+            finally:
+                if eval_registry_token:
+                    _experiment_eval_functions_var.reset(eval_registry_token)
+                experiment_context_var.reset(token)
+                if experiment_id_val:
+                    await finish_experiment_api(id=experiment_id_val)
+            
+            return result
+        return wrapper
+    return inner_decorator
+
+__all__ = ["experiment", "get_current_experiment_context", "ExperimentContext", "ExperimentOptions", "register_eval_function"] 

--- a/src/gentrace/lib/experiment_control.py
+++ b/src/gentrace/lib/experiment_control.py
@@ -1,0 +1,76 @@
+import logging
+from typing import Any, Dict, Union, Literal, Optional
+
+from .._types import NOT_GIVEN
+from .client_handles import experiments_async
+
+logger = logging.getLogger("gentrace")
+
+"""
+This module provides the core experiment control functionality for the Gentrace Python SDK.
+It includes types and functions for starting and finishing experiments via the Gentrace API.
+"""
+
+async def start_experiment_api(
+    *,
+    pipelineId: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    name: Optional[str] = None,
+) -> str:
+    """
+    Starts a new experiment run by creating an experiment record via the Gentrace API.
+    
+    Args:
+        pipelineId: The ID of the pipeline to create the experiment for.
+        metadata: Optional metadata for the experiment.
+        name: Friendly experiment name.
+               
+    Returns:
+        str: The unique ID of the created experiment run.
+    """
+    logger.debug(f"Attempting to start Gentrace experiment via API for pipeline ID `{pipelineId}` with name `{name}`.")
+    experiment = await experiments_async.create(
+        pipeline_id=pipelineId,
+        metadata=metadata if metadata is not None else NOT_GIVEN,
+        name=name if name is not None else NOT_GIVEN,
+    )
+    
+    return experiment.id
+
+async def finish_experiment_api(*, id: str, error: Optional[Union[Exception, str]] = None) -> None:
+    """
+    Finishes an experiment run by updating its status via the Gentrace API.
+    
+    Args:
+        id: The ID of the experiment to finish.
+        error: Optional error information. If provided, it will be logged.
+    """
+    logger.debug(f"Attempting to finish Gentrace experiment via API for experiment ID `{id}`.")
+    
+    status_to_set: Literal["EVALUATING"] = "EVALUATING"
+    # In the future, if the API supports errorMessage, it would be set here.
+    # For now, we will log the error if present.
+
+    if error:
+        error_message = str(error) if isinstance(error, Exception) else error
+        logger.info(f"Finishing Gentrace experiment `{id}` with a recorded error. Error details: {error_message}")
+        # If there was an error, the status on the backend might be handled differently
+        # or this might imply a different status if the API allowed. For now, we proceed
+        # to set it to EVALUATING as per Node.js SDK's apparent behavior, or this
+        # could be a point to set a specific "ERROR" status if available.
+
+    try:
+        await experiments_async.update(
+            id,
+            status=status_to_set,
+        )
+        logger.info(f"Successfully updated Gentrace experiment `{id}` to status `{status_to_set}` via API.")
+    except Exception as e:
+        logger.error(f"Failed to update Gentrace experiment `{id}` status via API. Details: {e}")
+        # Optionally re-raise or handle as appropriate for the SDK's error handling strategy
+        raise
+
+__all__ = [
+    "start_experiment_api",
+    "finish_experiment_api",
+]

--- a/src/gentrace/lib/utils.py
+++ b/src/gentrace/lib/utils.py
@@ -122,4 +122,18 @@ def gentrace_format_otel_attributes(attributes: Dict[str, Any]) -> Dict[str, ote
     return {key: gentrace_format_otel_value(value) for key, value in attributes.items()}
 
 
-__all__ = ["gentrace_format_otel_attributes", "gentrace_format_otel_value", "_gentrace_json_dumps"]
+# Placeholder for Pydantic version check
+def is_pydantic_v1() -> bool:
+    """Checks if the installed Pydantic version is V1."""
+    # Actual implementation would involve checking pydantic.__version__
+    # For now, returning a default, e.g., False if V2 is assumed more common.
+    # Replace with real logic: from pydantic import VERSION; return VERSION.startswith("1.")
+    try:
+        from pydantic import VERSION
+
+        return VERSION.startswith("1.")
+    except ImportError:
+        return False  # Or raise an error if pydantic is a core dependency
+
+
+__all__ = ["gentrace_format_otel_attributes", "gentrace_format_otel_value", "_gentrace_json_dumps", "is_pydantic_v1"]

--- a/tests/test_eval_dataset.py
+++ b/tests/test_eval_dataset.py
@@ -1,0 +1,281 @@
+from typing import Any
+
+import pytest
+
+import gentrace.lib.experiment as exp_mod
+import gentrace.lib.experiment_control as exp_ctrl
+
+
+# Automatically stub out experiment API calls to avoid real network interactions
+@pytest.fixture(autouse=True)
+def _stub_experiment_api(monkeypatch: Any) -> None:  # type: ignore
+    async def fake_start_experiment_api(*_: Any, **__: Any) -> str:
+        return "dummy-experiment-id"
+
+    async def fake_finish_experiment_api(*_: Any, **__: Any) -> None:
+        return None
+
+    monkeypatch.setattr(exp_ctrl, "start_experiment_api", fake_start_experiment_api)
+    monkeypatch.setattr(exp_mod, "start_experiment_api", fake_start_experiment_api)
+    monkeypatch.setattr(exp_ctrl, "finish_experiment_api", fake_finish_experiment_api)
+    monkeypatch.setattr(exp_mod, "finish_experiment_api", fake_finish_experiment_api)
+
+
+import asyncio
+from typing import Any, Dict, Union, Sequence
+
+from pydantic import BaseModel
+from _pytest.logging import LogCaptureFixture
+
+from gentrace import TestInput as GentraceTestInput, experiment
+from gentrace.types import TestCase as GentraceTestCase
+from gentrace.lib.utils import is_pydantic_v1
+from gentrace.lib.eval_dataset import eval_dataset
+
+PIPELINE_ID = "76ecc73d-3419-431f-aafc-93a9d1af1b83"
+
+
+# Setup - Helper Models, Functions, Data Providers
+
+
+class InputModel(BaseModel):
+    a: str
+    b: int
+
+
+class SimpleTestCase(GentraceTestCase):
+    pass
+
+
+class SimpleTestInputDict(GentraceTestInput[Dict[str, Any]]):
+    pass
+
+
+# Helper to convert Pydantic model based on version
+def model_to_dict(model: BaseModel) -> Dict[str, Any]:
+    if is_pydantic_v1():
+        return model.dict()  # type: ignore
+    else:
+        return model.model_dump()
+
+
+# Interaction Functions
+def sync_interaction(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    return {"result": f"{inputs.get('a', '')}-{inputs.get('b', 0)}"}
+
+
+async def async_interaction(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    await asyncio.sleep(0.01)
+    return {"result": f"async-{inputs.get('a', '')}-{inputs.get('b', 0)}"}
+
+
+# Data Providers
+def sync_data_provider_dict() -> Sequence[SimpleTestInputDict]:
+    return [
+        SimpleTestInputDict(name="case1", inputs={"a": "hello", "b": 1}),
+        SimpleTestInputDict(name="case2", inputs={"a": "world", "b": 2}),
+    ]
+
+
+async def async_data_provider_dict() -> Sequence[SimpleTestInputDict]:
+    await asyncio.sleep(0.01)
+    return [
+        SimpleTestInputDict(name="async_case1", inputs={"a": "hello_async", "b": 10}),
+        SimpleTestInputDict(name="async_case2", inputs={"a": "world_async", "b": 20}),
+    ]
+
+
+# Provide dummy required fields for TestCase initialization
+DUMMY_PIPELINE_ID = "test-pipeline-id"
+DUMMY_DATASET_ID = "test-dataset-id"
+DUMMY_CREATED_AT = "2023-01-01T00:00:00Z"
+DUMMY_UPDATED_AT = "2023-01-01T00:00:00Z"
+
+
+def sync_data_provider_testcase() -> Sequence[SimpleTestCase]:
+    input1_dict = model_to_dict(InputModel(a="tc_hello", b=100))
+    input2_dict = model_to_dict(InputModel(a="tc_world", b=200))
+    return [
+        SimpleTestCase(
+            id="tc1",
+            name="case_tc1",
+            inputs=input1_dict,
+            pipelineId=DUMMY_PIPELINE_ID,
+            datasetId=DUMMY_DATASET_ID,
+            createdAt=DUMMY_CREATED_AT,
+            updatedAt=DUMMY_UPDATED_AT,
+        ),
+        SimpleTestCase(
+            id="tc2",
+            name="case_tc2",
+            inputs=input2_dict,
+            pipelineId=DUMMY_PIPELINE_ID,
+            datasetId=DUMMY_DATASET_ID,
+            createdAt=DUMMY_CREATED_AT,
+            updatedAt=DUMMY_UPDATED_AT,
+        ),
+    ]
+
+
+def sync_data_provider_mixed() -> Sequence[Union[SimpleTestCase, SimpleTestInputDict]]:
+    input1_dict = model_to_dict(InputModel(a="tc_hello", b=100))
+    input4_dict = model_to_dict(InputModel(a="tc_noname", b=4))
+    return [
+        SimpleTestCase(
+            id="tc1",
+            name="case_tc1",
+            inputs=input1_dict,
+            pipelineId=DUMMY_PIPELINE_ID,
+            datasetId=DUMMY_DATASET_ID,
+            createdAt=DUMMY_CREATED_AT,
+            updatedAt=DUMMY_UPDATED_AT,
+        ),
+        SimpleTestInputDict(name="dict_case2", inputs={"a": "dict_world", "b": 2}),
+        SimpleTestInputDict(inputs={"a": "nameless_dict", "b": 3}),
+        SimpleTestCase(
+            id="tc4_noid",
+            name="tc4_noname_case",
+            inputs=input4_dict,
+            pipelineId=DUMMY_PIPELINE_ID,
+            datasetId=DUMMY_DATASET_ID,
+            createdAt=DUMMY_CREATED_AT,
+            updatedAt=DUMMY_UPDATED_AT,
+        ),
+    ]
+
+
+def sync_data_provider_invalid_for_schema() -> Sequence[SimpleTestInputDict]:
+    return [
+        SimpleTestInputDict(name="valid_case", inputs={"a": "ok", "b": 1}),
+        SimpleTestInputDict(name="invalid_case_missing_b", inputs={"a": "bad"}),
+        SimpleTestInputDict(name="invalid_case_wrong_type", inputs={"a": "bad2", "b": "not_an_int"}),
+    ]
+
+
+# Tests
+
+
+@pytest.mark.asyncio
+async def test_eval_dataset_outside_experiment() -> None:
+    """Verify eval_dataset raises RuntimeError when called outside @experiment."""
+    with pytest.raises(RuntimeError) as excinfo:
+        await eval_dataset(
+            data=sync_data_provider_dict,
+            interaction=sync_interaction,
+        )
+    assert "eval_dataset must be called within the context" in str(excinfo.value)
+
+
+@experiment(pipeline_id=PIPELINE_ID)
+@pytest.mark.asyncio
+async def test_eval_dataset_sync_interaction_sync_data() -> None:
+    """Test eval_dataset with sync interaction and sync data provider (dicts)."""
+    results = await eval_dataset(
+        data=sync_data_provider_dict,
+        interaction=sync_interaction,
+    )
+    assert len(results) == 2
+    assert results[0] == {"result": "hello-1"}
+    assert results[1] == {"result": "world-2"}
+
+
+@experiment(pipeline_id=PIPELINE_ID)
+@pytest.mark.asyncio
+async def test_eval_dataset_async_interaction_sync_data() -> None:
+    """Test eval_dataset with async interaction and sync data provider (dicts)."""
+    results = await eval_dataset(
+        data=sync_data_provider_dict,
+        interaction=async_interaction,
+    )
+    assert len(results) == 2
+    assert results[0] == {"result": "async-hello-1"}
+    assert results[1] == {"result": "async-world-2"}
+
+
+@experiment(pipeline_id=PIPELINE_ID)
+@pytest.mark.asyncio
+async def test_eval_dataset_sync_interaction_async_data() -> None:
+    """Test eval_dataset with sync interaction and async data provider (dicts)."""
+    results = await eval_dataset(
+        data=async_data_provider_dict,
+        interaction=sync_interaction,
+    )
+    assert len(results) == 2
+    assert results[0] == {"result": "hello_async-10"}
+    assert results[1] == {"result": "world_async-20"}
+
+
+@experiment(pipeline_id=PIPELINE_ID)
+@pytest.mark.asyncio
+async def test_eval_dataset_async_interaction_async_data() -> None:
+    """Test eval_dataset with async interaction and async data provider (dicts)."""
+    results = await eval_dataset(
+        data=async_data_provider_dict,
+        interaction=async_interaction,
+    )
+    assert len(results) == 2
+    assert results[0] == {"result": "async-hello_async-10"}
+    assert results[1] == {"result": "async-world_async-20"}
+
+
+@experiment(pipeline_id=PIPELINE_ID)
+@pytest.mark.asyncio
+async def test_eval_dataset_with_testcase_objects() -> None:
+    """Test eval_dataset using TestCase objects as input."""
+    results = await eval_dataset(
+        data=sync_data_provider_testcase,
+        interaction=sync_interaction,
+    )
+    assert len(results) == 2
+    assert results[0] == {"result": "tc_hello-100"}
+    assert results[1] == {"result": "tc_world-200"}
+
+
+@experiment(pipeline_id=PIPELINE_ID)
+@pytest.mark.asyncio
+async def test_eval_dataset_with_mixed_inputs() -> None:
+    """Test eval_dataset using a mix of TestCase objects and dicts, and check naming."""
+    results = await eval_dataset(
+        data=sync_data_provider_mixed,
+        interaction=sync_interaction,
+    )
+    assert len(results) == 4
+    assert results[0] == {"result": "tc_hello-100"}
+    assert results[1] == {"result": "dict_world-2"}
+    assert results[2] == {"result": "nameless_dict-3"}
+    assert results[3] == {"result": "tc_noname-4"}
+
+
+@experiment(pipeline_id=PIPELINE_ID)
+@pytest.mark.asyncio
+async def test_eval_dataset_with_schema_success() -> None:
+    """Test eval_dataset with a Pydantic schema and valid data."""
+    results = await eval_dataset(
+        data=sync_data_provider_dict,
+        schema=InputModel,
+        interaction=sync_interaction,
+    )
+    assert len(results) == 2
+    assert results[0] == {"result": "hello-1"}
+    assert results[1] == {"result": "world-2"}
+
+
+@experiment(pipeline_id=PIPELINE_ID)
+@pytest.mark.asyncio
+async def test_eval_dataset_with_schema_failure(caplog: LogCaptureFixture) -> None:
+    """Test eval_dataset with a Pydantic schema and invalid data. Expect None for failed cases."""
+    results = await eval_dataset(
+        data=sync_data_provider_invalid_for_schema,
+        schema=InputModel,
+        interaction=sync_interaction,
+    )
+
+    assert len(results) == 3
+    assert results[0] == {"result": "ok-1"}
+    assert results[1] is None
+    assert results[2] is None
+
+    assert "Pydantic validation failed for test case invalid_case_missing_b" in caplog.text
+    assert "Pydantic validation failed for test case invalid_case_wrong_type" in caplog.text
+    assert '{"result": "bad-0"}' not in caplog.text
+    assert '{"result": "bad2-0"}' not in caplog.text

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -6,14 +6,17 @@ import pytest
 from pytest import LogCaptureFixture
 
 from gentrace.lib.experiment import (
+    # ExperimentContext, # Will be used later
     ExperimentOptions,
+    # register_eval_function, # REMOVED
     experiment,
-    register_eval_function,
-    get_current_experiment_context,
+    get_current_experiment_context,  # Will be used later
 )
 
 # Get a direct reference to the module where experiment() is defined
 experiment_module_object = sys.modules["gentrace.lib.experiment"]
+
+PIPELINE_ID = "04b20fda-dbbe-4849-a927-3906fe743ef5"
 
 
 @pytest.mark.asyncio
@@ -25,14 +28,13 @@ async def test_experiment_decorator_simple_async_function() -> None:
     ) as mock_finish_api:
         mock_start_api.return_value = "test_experiment_id"
 
-        @experiment(pipeline_id="test_pipeline")
-        async def sample_async_function() -> str:
-            return "result"
+        @experiment(pipeline_id=PIPELINE_ID)
+        async def sample_async_function() -> None:
+            pass
 
-        result = await sample_async_function()
+        await sample_async_function()
 
-        assert result == "result"
-        mock_start_api.assert_called_once_with(pipelineId="test_pipeline", name=None, metadata=None)
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name=None, metadata=None)
         mock_finish_api.assert_called_once_with(id="test_experiment_id")
 
 
@@ -45,15 +47,14 @@ async def test_experiment_decorator_simple_sync_function() -> None:
     ) as mock_finish_api:
         mock_start_api.return_value = "test_experiment_id_sync"
 
-        @experiment(pipeline_id="test_pipeline_sync")
-        def sample_sync_function() -> str:
-            return "sync_result"
+        @experiment(pipeline_id=PIPELINE_ID)
+        def sample_sync_function() -> None:
+            pass
 
         # Even though sample_sync_function is sync, the decorator makes it awaitable
-        result = await sample_sync_function()
+        await sample_sync_function()
 
-        assert result == "sync_result"
-        mock_start_api.assert_called_once_with(pipelineId="test_pipeline_sync", name=None, metadata=None)
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name=None, metadata=None)
         mock_finish_api.assert_called_once_with(id="test_experiment_id_sync")
 
 
@@ -66,18 +67,18 @@ async def test_experiment_context_is_set_and_retrievable() -> None:
     ) as mock_finish_api:
         mock_start_api.return_value = "exp_id_context_test"
 
-        @experiment(pipeline_id="pipeline_for_context")
+        @experiment(pipeline_id=PIPELINE_ID)
         async def function_with_context_check() -> None:
             context = get_current_experiment_context()
             assert context is not None
             assert context["experiment_id"] == "exp_id_context_test"
-            assert context["pipeline_id"] == "pipeline_for_context"
+            assert context["pipeline_id"] == PIPELINE_ID
 
             # Check context variable directly too
             raw_context = experiment_module_object.experiment_context_var.get()
             assert raw_context is not None
             assert raw_context["experiment_id"] == "exp_id_context_test"
-            assert raw_context["pipeline_id"] == "pipeline_for_context"
+            assert raw_context["pipeline_id"] == PIPELINE_ID
 
         await function_with_context_check()
 
@@ -85,7 +86,7 @@ async def test_experiment_context_is_set_and_retrievable() -> None:
         assert experiment_module_object.experiment_context_var.get() is None
         assert get_current_experiment_context() is None
 
-        mock_start_api.assert_called_once_with(pipelineId="pipeline_for_context", name=None, metadata=None)
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name=None, metadata=None)
         mock_finish_api.assert_called_once_with(id="exp_id_context_test")
 
 
@@ -111,15 +112,14 @@ async def test_experiment_decorator_with_options() -> None:
             "metadata": experiment_metadata,
         }
 
-        @experiment(pipeline_id="pipeline_with_options", options=options)
-        async def function_with_options() -> str:
-            return "options_result"
+        @experiment(pipeline_id=PIPELINE_ID, options=options)
+        async def function_with_options() -> None:
+            pass
 
-        result = await function_with_options()
+        await function_with_options()
 
-        assert result == "options_result"
         mock_start_api.assert_called_once_with(
-            pipelineId="pipeline_with_options",
+            pipelineId=PIPELINE_ID,
             name=experiment_name,
             metadata=experiment_metadata,
         )
@@ -135,25 +135,25 @@ async def test_experiment_decorator_start_api_fails() -> None:
     ) as mock_finish_api:
         mock_start_api.side_effect = ValueError("API start failed")
 
-        @experiment(pipeline_id="pipeline_api_fail")
-        async def function_where_api_fails() -> str:
-            # This part should not be reached
-            return "should_not_return"
+        @experiment(pipeline_id=PIPELINE_ID)
+        async def function_where_api_fails() -> None:
+            pass
 
         with pytest.raises(ValueError, match="API start failed"):
             await function_where_api_fails()
 
-        mock_start_api.assert_called_once_with(pipelineId="pipeline_api_fail", name=None, metadata=None)
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name=None, metadata=None)
         mock_finish_api.assert_not_called()
         # Context should not be set if start_api failed before setting it
         assert experiment_module_object.experiment_context_var.get() is None
 
 
 @pytest.mark.asyncio
-async def test_experiment_with_sync_eval_function() -> None:
+async def test_experiment_with_called_sync_function() -> None:
     mock_eval_function = MagicMock()
 
-    def simple_eval() -> str:
+    # This function would conceptually be decorated with @eval in real usage
+    def simple_eval_like_function() -> str:
         mock_eval_function()
         return "eval_result"
 
@@ -164,28 +164,25 @@ async def test_experiment_with_sync_eval_function() -> None:
     ) as mock_finish_api:
         mock_start_api.return_value = "exp_id_sync_eval"
 
-        @experiment(pipeline_id="pipeline_sync_eval")
-        async def experiment_with_eval() -> str:
-            # Simulate @eval decorator by calling register_eval_function directly
-            # In real code, @eval would call this.
-            register_eval_function(simple_eval)
-            return "main_result"
+        @experiment(pipeline_id=PIPELINE_ID)
+        async def experiment_with_eval() -> None:
+            simple_eval_like_function()  # Directly call the function
+            pass
 
-        result = await experiment_with_eval()
+        await experiment_with_eval()
 
-        assert result == "main_result"
-        mock_start_api.assert_called_once_with(pipelineId="pipeline_sync_eval", name=None, metadata=None)
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name=None, metadata=None)
         mock_finish_api.assert_called_once_with(id="exp_id_sync_eval")
         mock_eval_function.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_experiment_with_async_eval_function() -> None:
+async def test_experiment_with_called_async_function() -> None:
     mock_async_eval_function = AsyncMock()
 
-    async def simple_async_eval() -> str:
+    # This function would conceptually be decorated with @eval in real usage
+    async def simple_async_eval_like_function() -> None:
         await mock_async_eval_function()
-        return "async_eval_result"
 
     with patch.object(
         experiment_module_object, "start_experiment_api", new_callable=AsyncMock
@@ -194,21 +191,20 @@ async def test_experiment_with_async_eval_function() -> None:
     ) as mock_finish_api:
         mock_start_api.return_value = "exp_id_async_eval"
 
-        @experiment(pipeline_id="pipeline_async_eval")
-        async def experiment_with_async_eval() -> str:
-            register_eval_function(simple_async_eval)
-            return "main_async_result"
+        @experiment(pipeline_id=PIPELINE_ID)
+        async def experiment_with_async_eval() -> None:
+            await simple_async_eval_like_function()  # Directly call and await
+            pass
 
-        result = await experiment_with_async_eval()
+        await experiment_with_async_eval()
 
-        assert result == "main_async_result"
-        mock_start_api.assert_called_once_with(pipelineId="pipeline_async_eval", name=None, metadata=None)
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name=None, metadata=None)
         mock_finish_api.assert_called_once_with(id="exp_id_async_eval")
         mock_async_eval_function.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_experiment_with_multiple_eval_functions() -> None:
+async def test_experiment_with_multiple_called_functions() -> None:
     mock_eval1 = MagicMock()
     mock_eval2_async = AsyncMock()
 
@@ -225,26 +221,27 @@ async def test_experiment_with_multiple_eval_functions() -> None:
     ) as mock_finish_api:
         mock_start_api.return_value = "exp_id_multiple_eval"
 
-        @experiment(pipeline_id="pipeline_multiple_eval")
-        async def experiment_with_multiple_evals() -> str:
-            register_eval_function(sync_eval_1)
-            register_eval_function(async_eval_2)
-            return "main_multiple_result"
+        @experiment(pipeline_id=PIPELINE_ID)
+        async def experiment_with_multiple_evals() -> None:
+            sync_eval_1()
+            await async_eval_2()
 
-        result = await experiment_with_multiple_evals()
+        await experiment_with_multiple_evals()
 
-        assert result == "main_multiple_result"
-        mock_start_api.assert_called_once_with(pipelineId="pipeline_multiple_eval", name=None, metadata=None)
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name=None, metadata=None)
         mock_finish_api.assert_called_once_with(id="exp_id_multiple_eval")
         mock_eval1.assert_called_once()
         mock_eval2_async.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_experiment_eval_function_raises_exception(caplog: LogCaptureFixture) -> None:
+async def test_experiment_called_function_raises_exception() -> None:
     eval_exception = ValueError("Eval failed")
 
-    def faulty_eval() -> None:
+    # This function would be decorated with @eval in real use.
+    # The @eval decorator would handle exception recording.
+    # For this test, we just care the experiment finishes.
+    def faulty_function_called_in_experiment() -> None:
         raise eval_exception
 
     with patch.object(
@@ -254,78 +251,49 @@ async def test_experiment_eval_function_raises_exception(caplog: LogCaptureFixtu
     ) as mock_finish_api:
         mock_start_api.return_value = "exp_id_eval_fail"
 
-        @experiment(pipeline_id="pipeline_eval_fail")
-        async def experiment_where_eval_fails() -> str:
-            register_eval_function(faulty_eval)
-            return "main_result_eval_fail"
+        @experiment(pipeline_id=PIPELINE_ID)
+        async def experiment_where_internal_call_fails() -> None:
+            # The exception from faulty_function_called_in_experiment will propagate
+            # and be caught by the test's `pytest.raises` or by pytest itself if unhandled.
+            faulty_function_called_in_experiment()
 
-        result = await experiment_where_eval_fails()
+        # The experiment decorator itself doesn't catch exceptions from the user's code,
+        # it ensures finish_experiment_api is called in a finally block.
+        with pytest.raises(ValueError, match="Eval failed"):
+            await experiment_where_internal_call_fails()
 
-        assert result == "main_result_eval_fail"
-
-        mock_start_api.assert_called_once_with(pipelineId="pipeline_eval_fail", name=None, metadata=None)
+        # finish_experiment_api should still be called due to the finally block
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name=None, metadata=None)
         mock_finish_api.assert_called_once_with(id="exp_id_eval_fail")
 
-        # Check that the error was logged
-        assert len(caplog.records) >= 1
-        found_log = False
-        for record in caplog.records:
-            if (
-                record.levelname == "ERROR"
-                and "@eval function `faulty_eval` encountered an unexpected error. Details: Eval failed"
-                in record.message
-            ):
-                found_log = True
-                break
-        assert found_log, "Expected error log message not found for faulty_eval"
+        # No specific logging from @experiment about @eval errors anymore
+        # Assertions about specific @eval error logs are removed.
+        # If @eval itself logs, that would be separate.
 
 
-def test_register_eval_function_outside_experiment_context(caplog: LogCaptureFixture) -> None:
-    mock_standalone_eval = MagicMock()
-
-    def standalone_eval_func() -> None:
-        mock_standalone_eval()
-
-    assert experiment_module_object.experiment_context_var.get() is None
-    assert experiment_module_object._experiment_eval_functions_var.get() is None
-
-    # Clear previous logs if any, and set level to capture WARNING
-    caplog.clear()
-    caplog.set_level(logging.WARNING)  # Ensure WARNING level is captured
-
-    register_eval_function(standalone_eval_func)
-
-    mock_standalone_eval.assert_not_called()
-
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
-    assert record.levelname == "WARNING"
-    assert "The @eval decorator was used on function `standalone_eval_func`" in record.message
-    assert "outside of an active @experiment context" in record.message
-    assert "This @eval function will not be automatically executed" in record.message
+# Removed test_register_eval_function_outside_experiment_context as it's no longer applicable
 
 
 @pytest.mark.asyncio
-async def test_experiment_with_mixed_eval_outcomes(caplog: LogCaptureFixture) -> None:
+async def test_experiment_with_mixed_outcomes_in_called_functions(caplog: LogCaptureFixture) -> None:
     mock_success_indicator = MagicMock()
     mock_assertion_before_error = MagicMock()
-    mock_value_before_error = MagicMock()
-    # This mock should not be called as it's after an error in its eval function
-    mock_after_error_in_eval = MagicMock()
 
-    def successful_eval() -> str:
+    # This function would be @eval decorated
+    def successful_called_func() -> str:
         mock_success_indicator()
         return "success"
 
-    def assertion_error_eval() -> None:
+    # This function would be @eval decorated. The @eval decorator would handle the AssertionError.
+    def assertion_error_called_func() -> None:
         mock_assertion_before_error()
         raise AssertionError("This is a test assertion error")
 
-    async def value_error_eval() -> None:
-        mock_value_before_error()
+    # This function would be @eval decorated. The @eval decorator would handle the ValueError.
+    async def value_error_called_func() -> None:
         raise ValueError("This is a test value error")
 
-    caplog.set_level(logging.DEBUG)  # Capture DEBUG and above
+    caplog.set_level(logging.DEBUG)
 
     with patch.object(
         experiment_module_object, "start_experiment_api", new_callable=AsyncMock
@@ -334,39 +302,38 @@ async def test_experiment_with_mixed_eval_outcomes(caplog: LogCaptureFixture) ->
     ) as mock_finish_api:
         mock_start_api.return_value = "exp_id_mixed_outcomes"
 
-        @experiment(pipeline_id="pipeline_mixed_outcomes", options={"name": "MixedTest"})
-        async def experiment_with_mixed_evals() -> str:
-            register_eval_function(successful_eval)
-            register_eval_function(assertion_error_eval)
-            register_eval_function(value_error_eval)
-            return "main_mixed_result"
+        @experiment(pipeline_id=PIPELINE_ID, options={"name": "MixedTest"})
+        async def experiment_with_mixed_calls() -> None:
+            successful_called_func()
 
-        main_result = await experiment_with_mixed_evals()
+            try:
+                assertion_error_called_func()
+            except AssertionError:
+                # In a real scenario with @eval, @eval's wrapper would catch this.
+                # Here, the experiment itself doesn't catch it, so the test needs to
+                # simulate that the error is handled by simply passing, allowing the experiment to continue.
+                pass
 
-        assert main_result == "main_mixed_result"
-        mock_start_api.assert_called_once_with(pipelineId="pipeline_mixed_outcomes", name="MixedTest", metadata=None)
+            try:
+                await value_error_called_func()
+            except ValueError:
+                # Similar to above, @eval would handle, experiment doesn't.
+                pass
+
+        await experiment_with_mixed_calls()
+
+        mock_start_api.assert_called_once_with(pipelineId=PIPELINE_ID, name="MixedTest", metadata=None)
         mock_finish_api.assert_called_once_with(id="exp_id_mixed_outcomes")
 
         mock_success_indicator.assert_called_once()
         mock_assertion_before_error.assert_called_once()
-        mock_value_before_error.assert_called_once()
-        mock_after_error_in_eval.assert_not_called()
 
-        logs = [(r.levelname, r.message) for r in caplog.records]
+        # Logging assertions about "Executing @eval function" are removed as that mechanism is gone.
+        # Any logging would now come from the @eval decorator itself when the functions are called.
+        # This test primarily focuses on the @experiment decorator's behavior.
 
-        assert ("DEBUG", "Experiment `MixedTest`: Executing 3 registered @eval function(s).") in logs
-
-        assert ("DEBUG", "Executing @eval function: `successful_eval`.") in logs
-        assert ("DEBUG", "@eval function `successful_eval` completed successfully.") in logs
-
-        assert ("DEBUG", "Executing @eval function: `assertion_error_eval`.") in logs
-        assert (
-            "ERROR",
-            "@eval function `assertion_error_eval` failed with an AssertionError. Details: This is a test assertion error\nassert False",
-        ) in logs
-
-        assert ("DEBUG", "Executing @eval function: `value_error_eval`.") in logs
-        assert (
-            "ERROR",
-            "@eval function `value_error_eval` encountered an unexpected error. Details: This is a test value error",
-        ) in logs
+        # Example: if @eval logs something specific, we could check for that.
+        # For now, we confirm the experiment completes and the main mocks are called.
+        initial_log_messages = [r.message for r in caplog.records]
+        assert not any("Executing @eval function:" in msg for msg in initial_log_messages)
+        assert not any("Experiment `MixedTest`: Executing" in msg for msg in initial_log_messages)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,372 @@
+import sys
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pytest import LogCaptureFixture
+
+from gentrace.lib.experiment import (
+    ExperimentOptions,
+    experiment,
+    register_eval_function,
+    get_current_experiment_context,
+)
+
+# Get a direct reference to the module where experiment() is defined
+experiment_module_object = sys.modules["gentrace.lib.experiment"]
+
+
+@pytest.mark.asyncio
+async def test_experiment_decorator_simple_async_function() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "test_experiment_id"
+
+        @experiment(pipeline_id="test_pipeline")
+        async def sample_async_function() -> str:
+            return "result"
+
+        result = await sample_async_function()
+
+        assert result == "result"
+        mock_start_api.assert_called_once_with(pipelineId="test_pipeline", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="test_experiment_id")
+
+
+@pytest.mark.asyncio
+async def test_experiment_decorator_simple_sync_function() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "test_experiment_id_sync"
+
+        @experiment(pipeline_id="test_pipeline_sync")
+        def sample_sync_function() -> str:
+            return "sync_result"
+
+        # Even though sample_sync_function is sync, the decorator makes it awaitable
+        result = await sample_sync_function()
+
+        assert result == "sync_result"
+        mock_start_api.assert_called_once_with(pipelineId="test_pipeline_sync", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="test_experiment_id_sync")
+
+
+@pytest.mark.asyncio
+async def test_experiment_context_is_set_and_retrievable() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_context_test"
+
+        @experiment(pipeline_id="pipeline_for_context")
+        async def function_with_context_check() -> None:
+            context = get_current_experiment_context()
+            assert context is not None
+            assert context["experiment_id"] == "exp_id_context_test"
+            assert context["pipeline_id"] == "pipeline_for_context"
+
+            # Check context variable directly too
+            raw_context = experiment_module_object.experiment_context_var.get()
+            assert raw_context is not None
+            assert raw_context["experiment_id"] == "exp_id_context_test"
+            assert raw_context["pipeline_id"] == "pipeline_for_context"
+
+        await function_with_context_check()
+
+        # Context should be reset outside the function
+        assert experiment_module_object.experiment_context_var.get() is None
+        assert get_current_experiment_context() is None
+
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_for_context", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_context_test")
+
+
+@pytest.mark.asyncio
+async def test_get_current_experiment_context_outside_experiment() -> None:
+    assert get_current_experiment_context() is None
+    assert experiment_module_object.experiment_context_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_experiment_decorator_with_options() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_options_test"
+        experiment_name = "My Test Experiment"
+        experiment_metadata = {"version": "1.0", "user": "test_user"}
+
+        options: ExperimentOptions = {
+            "name": experiment_name,
+            "metadata": experiment_metadata,
+        }
+
+        @experiment(pipeline_id="pipeline_with_options", options=options)
+        async def function_with_options() -> str:
+            return "options_result"
+
+        result = await function_with_options()
+
+        assert result == "options_result"
+        mock_start_api.assert_called_once_with(
+            pipelineId="pipeline_with_options",
+            name=experiment_name,
+            metadata=experiment_metadata,
+        )
+        mock_finish_api.assert_called_once_with(id="exp_id_options_test")
+
+
+@pytest.mark.asyncio
+async def test_experiment_decorator_start_api_fails() -> None:
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.side_effect = ValueError("API start failed")
+
+        @experiment(pipeline_id="pipeline_api_fail")
+        async def function_where_api_fails() -> str:
+            # This part should not be reached
+            return "should_not_return"
+
+        with pytest.raises(ValueError, match="API start failed"):
+            await function_where_api_fails()
+
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_api_fail", name=None, metadata=None)
+        mock_finish_api.assert_not_called()
+        # Context should not be set if start_api failed before setting it
+        assert experiment_module_object.experiment_context_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_experiment_with_sync_eval_function() -> None:
+    mock_eval_function = MagicMock()
+
+    def simple_eval() -> str:
+        mock_eval_function()
+        return "eval_result"
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_sync_eval"
+
+        @experiment(pipeline_id="pipeline_sync_eval")
+        async def experiment_with_eval() -> str:
+            # Simulate @eval decorator by calling register_eval_function directly
+            # In real code, @eval would call this.
+            register_eval_function(simple_eval)
+            return "main_result"
+
+        result = await experiment_with_eval()
+
+        assert result == "main_result"
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_sync_eval", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_sync_eval")
+        mock_eval_function.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_experiment_with_async_eval_function() -> None:
+    mock_async_eval_function = AsyncMock()
+
+    async def simple_async_eval() -> str:
+        await mock_async_eval_function()
+        return "async_eval_result"
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_async_eval"
+
+        @experiment(pipeline_id="pipeline_async_eval")
+        async def experiment_with_async_eval() -> str:
+            register_eval_function(simple_async_eval)
+            return "main_async_result"
+
+        result = await experiment_with_async_eval()
+
+        assert result == "main_async_result"
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_async_eval", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_async_eval")
+        mock_async_eval_function.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_experiment_with_multiple_eval_functions() -> None:
+    mock_eval1 = MagicMock()
+    mock_eval2_async = AsyncMock()
+
+    def sync_eval_1() -> None:
+        mock_eval1()
+
+    async def async_eval_2() -> None:
+        await mock_eval2_async()
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_multiple_eval"
+
+        @experiment(pipeline_id="pipeline_multiple_eval")
+        async def experiment_with_multiple_evals() -> str:
+            register_eval_function(sync_eval_1)
+            register_eval_function(async_eval_2)
+            return "main_multiple_result"
+
+        result = await experiment_with_multiple_evals()
+
+        assert result == "main_multiple_result"
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_multiple_eval", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_multiple_eval")
+        mock_eval1.assert_called_once()
+        mock_eval2_async.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_experiment_eval_function_raises_exception(caplog: LogCaptureFixture) -> None:
+    eval_exception = ValueError("Eval failed")
+
+    def faulty_eval() -> None:
+        raise eval_exception
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_eval_fail"
+
+        @experiment(pipeline_id="pipeline_eval_fail")
+        async def experiment_where_eval_fails() -> str:
+            register_eval_function(faulty_eval)
+            return "main_result_eval_fail"
+
+        result = await experiment_where_eval_fails()
+
+        assert result == "main_result_eval_fail"
+
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_eval_fail", name=None, metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_eval_fail")
+
+        # Check that the error was logged
+        assert len(caplog.records) >= 1
+        found_log = False
+        for record in caplog.records:
+            if (
+                record.levelname == "ERROR"
+                and "@eval function `faulty_eval` encountered an unexpected error. Details: Eval failed"
+                in record.message
+            ):
+                found_log = True
+                break
+        assert found_log, "Expected error log message not found for faulty_eval"
+
+
+def test_register_eval_function_outside_experiment_context(caplog: LogCaptureFixture) -> None:
+    mock_standalone_eval = MagicMock()
+
+    def standalone_eval_func() -> None:
+        mock_standalone_eval()
+
+    assert experiment_module_object.experiment_context_var.get() is None
+    assert experiment_module_object._experiment_eval_functions_var.get() is None
+
+    # Clear previous logs if any, and set level to capture WARNING
+    caplog.clear()
+    caplog.set_level(logging.WARNING)  # Ensure WARNING level is captured
+
+    register_eval_function(standalone_eval_func)
+
+    mock_standalone_eval.assert_not_called()
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "WARNING"
+    assert "The @eval decorator was used on function `standalone_eval_func`" in record.message
+    assert "outside of an active @experiment context" in record.message
+    assert "This @eval function will not be automatically executed" in record.message
+
+
+@pytest.mark.asyncio
+async def test_experiment_with_mixed_eval_outcomes(caplog: LogCaptureFixture) -> None:
+    mock_success_indicator = MagicMock()
+    mock_assertion_before_error = MagicMock()
+    mock_value_before_error = MagicMock()
+    # This mock should not be called as it's after an error in its eval function
+    mock_after_error_in_eval = MagicMock()
+
+    def successful_eval() -> str:
+        mock_success_indicator()
+        return "success"
+
+    def assertion_error_eval() -> None:
+        mock_assertion_before_error()
+        raise AssertionError("This is a test assertion error")
+
+    async def value_error_eval() -> None:
+        mock_value_before_error()
+        raise ValueError("This is a test value error")
+
+    caplog.set_level(logging.DEBUG)  # Capture DEBUG and above
+
+    with patch.object(
+        experiment_module_object, "start_experiment_api", new_callable=AsyncMock
+    ) as mock_start_api, patch.object(
+        experiment_module_object, "finish_experiment_api", new_callable=AsyncMock
+    ) as mock_finish_api:
+        mock_start_api.return_value = "exp_id_mixed_outcomes"
+
+        @experiment(pipeline_id="pipeline_mixed_outcomes", options={"name": "MixedTest"})
+        async def experiment_with_mixed_evals() -> str:
+            register_eval_function(successful_eval)
+            register_eval_function(assertion_error_eval)
+            register_eval_function(value_error_eval)
+            return "main_mixed_result"
+
+        main_result = await experiment_with_mixed_evals()
+
+        assert main_result == "main_mixed_result"
+        mock_start_api.assert_called_once_with(pipelineId="pipeline_mixed_outcomes", name="MixedTest", metadata=None)
+        mock_finish_api.assert_called_once_with(id="exp_id_mixed_outcomes")
+
+        mock_success_indicator.assert_called_once()
+        mock_assertion_before_error.assert_called_once()
+        mock_value_before_error.assert_called_once()
+        mock_after_error_in_eval.assert_not_called()
+
+        logs = [(r.levelname, r.message) for r in caplog.records]
+
+        assert ("DEBUG", "Experiment `MixedTest`: Executing 3 registered @eval function(s).") in logs
+
+        assert ("DEBUG", "Executing @eval function: `successful_eval`.") in logs
+        assert ("DEBUG", "@eval function `successful_eval` completed successfully.") in logs
+
+        assert ("DEBUG", "Executing @eval function: `assertion_error_eval`.") in logs
+        assert (
+            "ERROR",
+            "@eval function `assertion_error_eval` failed with an AssertionError. Details: This is a test assertion error\nassert False",
+        ) in logs
+
+        assert ("DEBUG", "Executing @eval function: `value_error_eval`.") in logs
+        assert (
+            "ERROR",
+            "@eval function `value_error_eval` encountered an unexpected error. Details: This is a test value error",
+        ) in logs

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,12 +1,13 @@
-import unittest
-from unittest.mock import MagicMock, patch
-import asyncio
 import uuid
+import asyncio
+import unittest
 from typing import Any, Dict, Tuple, Callable
+from unittest.mock import MagicMock, patch
 
-from gentrace.lib.interaction import interaction
-from opentelemetry.trace.status import StatusCode, Status
+from opentelemetry.trace.status import Status, StatusCode
+
 from gentrace.lib.utils import _gentrace_json_dumps
+from gentrace.lib.interaction import interaction
 
 
 class TestInteraction(unittest.TestCase):

--- a/tests/test_lib_init.py
+++ b/tests/test_lib_init.py
@@ -1,5 +1,5 @@
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from gentrace.lib.init import init as function_under_test
 

--- a/tests/test_traced.py
+++ b/tests/test_traced.py
@@ -1,10 +1,11 @@
-import unittest
-from unittest.mock import MagicMock, patch
 import uuid
+import unittest
 from typing import Tuple
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.trace.status import Status, StatusCode
 
 from gentrace.lib.traced import traced
-from opentelemetry.trace.status import StatusCode, Status
 
 
 class TestTraced(unittest.TestCase):


### PR DESCRIPTION
# Add `eval_dataset` function for batch evaluation of test cases

This PR adds a new `eval_dataset` function that enables running multiple test cases against an interaction function within a Gentrace experiment context.

The implementation includes:
- A new `TestInput` generic TypedDict for representing test cases
- Support for multiple ways to provide test data (lambda, async function, sync function)
- OpenTelemetry tracing for each test case execution
- Pydantic schema validation for test inputs
- Proper error handling with span attribution

The `eval_dataset` function must be called within an `@experiment` decorated function and processes each test case individually, recording traces and validation results.

Also included:
- Updated the `experiment` decorator to explicitly return `None`
- Added new exports to the package's `__init__.py`
- Added example code demonstrating usage patterns

Example usage:

```python
@experiment(pipeline_id="3210ca10-226a-41ae-8b5e-342a95bd59b1")
async def run_evaluation():
    # Run evaluation with inline test cases
    await eval_dataset(
        data=lambda: [
            TestInput(name="Test 1", inputs={"query": "Hello"}),
            TestInput(name="Test 2", inputs={"query": "World"})
        ],
        interaction=process_query,
        schema=QuerySchema
    )
    
    # Or fetch test cases from a dataset
    await eval_dataset(
        data=fetch_test_cases,  # async function that returns test cases
        interaction=process_query,
        schema=QuerySchema
    )
```