### PR TITLE
feat: Improve NUX for copying code snippets

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   claude-response:
     runs-on: ubuntu-latest
+    if: ${{ !endsWith(github.actor, '[bot]') }}
     permissions:
       contents: read
       pull-requests: read
@@ -23,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          
+
       - uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/examples/no_otel.py
+++ b/examples/no_otel.py
@@ -1,0 +1,55 @@
+"""
+This example demonstrates what happens when using Gentrace's @interaction decorator
+without setting up OpenTelemetry first. This will show warning/error messages about
+missing OpenTelemetry configuration.
+"""
+
+import os
+import asyncio
+
+from gentrace import interaction
+
+api_key = os.getenv("GENTRACE_API_KEY", "")
+pipeline_id = os.getenv("GENTRACE_PIPELINE_ID", "")
+
+if not api_key:
+    print("Warning: GENTRACE_API_KEY environment variable not set.")
+
+
+@interaction(pipeline_id=pipeline_id, name="test_sync_interaction")
+def my_sync_function(x: int, y: int) -> int:
+    result = x + y
+    print(f"Sync function executed: {x} + {y} = {result}")
+    return result
+
+
+@interaction(pipeline_id=pipeline_id, name="test_async_interaction")
+async def my_async_function(message: str) -> str:
+    await asyncio.sleep(0.1)
+    result = f"Processed: {message}"
+    print(f"Async function executed: {result}")
+    return result
+
+
+async def main() -> None:
+    print("Running Gentrace interactions without OpenTelemetry setup...\n")
+    
+    print("=== Testing synchronous interaction ===")
+    try:
+        sync_result = my_sync_function(5, 3)
+        print(f"Sync result: {sync_result}\n")
+    except Exception as e:
+        print(f"Error in sync function: {e}\n")
+    
+    print("=== Testing asynchronous interaction ===")
+    try:
+        async_result = await my_async_function("Hello Gentrace")
+        print(f"Async result: {async_result}\n")
+    except Exception as e:
+        print(f"Error in async function: {e}\n")
+    
+    print("\nNote: Check console output above for any warnings about missing OpenTelemetry configuration.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/src/gentrace/lib/utils.py
+++ b/src/gentrace/lib/utils.py
@@ -104,7 +104,7 @@ class GentraceConsole:
         """Create a styled table."""
         return Table(title=title, show_header=True, header_style="bold magenta", **kwargs)
 
-    def create_progress_bar(self, description: str = "Processing...") -> Progress:
+    def create_progress_bar(self) -> Progress:
         """Create a styled progress bar."""
         return Progress(
             SpinnerColumn(),

--- a/src/gentrace/lib/utils.py
+++ b/src/gentrace/lib/utils.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import warnings
-from typing import Any, Set, Dict, List, Union, Optional
+from typing import Any, Set, Dict, List, Union, Optional, Tuple, cast
 from datetime import datetime
 from collections.abc import Sequence
 
@@ -147,9 +147,12 @@ class GentraceConsole:
 
         for item in items:
             if isinstance(item, (list, tuple)) and columns:
-                table.add_row(*[str(elem) for elem in item])
+                # Cast item to sequence to help type checker
+                elem_list = cast(Union[List[Any], Tuple[Any, ...]], item)
+                table.add_row(*[str(elem) for elem in elem_list])
             else:
-                table.add_row(str(item))
+                # Cast to help type checker with the str() call
+                table.add_row(str(cast(Any, item)))
 
         self._console.print(table)
 
@@ -556,7 +559,8 @@ def print_evaluation_results(results: Dict[str, Any], title: str = "Evaluation R
     for key, value in results.items():
         if isinstance(value, dict):
             subtree = tree.add(f"[cyan]{key}[/cyan]")
-            for sub_k, sub_v in value.items():
+            value_dict = cast(Dict[str, Any], value)
+            for sub_k, sub_v in value_dict.items():
                 subtree.add(f"[green]{sub_k}[/green]: {sub_v}")
         else:
             tree.add(f"[green]{key}[/green]: {value}")

--- a/src/gentrace/lib/utils.py
+++ b/src/gentrace/lib/utils.py
@@ -1,11 +1,30 @@
 import json
 import logging
 import warnings
-from typing import Any, Set, Dict
+from typing import Any, Set, Dict, Optional, Union, List
+from datetime import datetime
+from collections.abc import Sequence
 
 from pydantic import BaseModel
 from rich.text import Text
-from rich.console import Console
+from rich.console import Console, Group, RenderableType
+from rich.table import Table, Column
+from rich.panel import Panel
+from rich.progress import (
+    Progress,
+    BarColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+    SpinnerColumn,
+    MofNCompleteColumn,
+    TaskID,
+)
+from rich.spinner import Spinner
+from rich.syntax import Syntax
+from rich.tree import Tree
+from rich.live import Live
+from rich.markdown import Markdown
 from opentelemetry import trace as trace_api
 from opentelemetry.util import types as otel_types
 from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
@@ -20,11 +39,275 @@ CIRCULAR_REFERENCE_PLACEHOLDER = "[CircularReference]"
 # Global flag to ensure the OpenTelemetry configuration warning is issued only once per session
 _otel_config_warning_issued = False
 
+# Default spinner style for Gentrace operations
+DEFAULT_SPINNER = "dots"
+
+
+class GentraceConsole:
+    """Centralized console management for Gentrace with rich formatting capabilities."""
+    
+    _instance: Optional['GentraceConsole'] = None
+    _console: Console
+    
+    def __new__(cls) -> 'GentraceConsole':
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._console = Console(stderr=True, highlight=True)
+        return cls._instance
+    
+    @property
+    def console(self) -> Console:
+        return self._console
+    
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        """Print with rich formatting."""
+        self._console.print(*args, **kwargs)
+    
+    def log(self, message: str, style: Optional[str] = None) -> None:
+        """Print a log message with optional styling."""
+        if style:
+            self._console.print(f"[{style}]{message}[/{style}]")
+        else:
+            self._console.print(message)
+    
+    def success(self, message: str) -> None:
+        """Print a success message."""
+        self._console.print(f"[green]✓[/green] {message}")
+    
+    def error(self, message: str) -> None:
+        """Print an error message."""
+        self._console.print(f"[red]✗[/red] {message}")
+    
+    def warning(self, message: str) -> None:
+        """Print a warning message."""
+        self._console.print(f"[yellow]⚠[/yellow] {message}")
+    
+    def info(self, message: str) -> None:
+        """Print an info message."""
+        self._console.print(f"[blue]ℹ[/blue] {message}")
+    
+    def step_progress(self, text: str = "") -> Spinner:
+        """Create a spinner for step progress."""
+        return Spinner(DEFAULT_SPINNER, text, style="blue")
+    
+    def step_completed(self, message: str) -> RenderableType:
+        """Return a renderable for completed step."""
+        return f"[green]✓[/green] {message}"
+    
+    def create_panel(self, content: Union[str, RenderableType], title: Optional[str] = None, 
+                    border_style: str = "blue") -> Panel:
+        """Create a styled panel."""
+        return Panel(content, title=title, border_style=border_style, title_align="left")
+    
+    def create_table(self, title: Optional[str] = None, **kwargs: Any) -> Table:
+        """Create a styled table."""
+        return Table(title=title, show_header=True, header_style="bold magenta", **kwargs)
+    
+    def create_progress_bar(self, description: str = "Processing...") -> Progress:
+        """Create a styled progress bar."""
+        return Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeRemainingColumn(),
+            console=self._console,
+            transient=True,
+        )
+    
+    def create_tree(self, label: RenderableType, guide_style: str = "gray50") -> Tree:
+        """Create a tree structure for hierarchical display."""
+        return Tree(label, guide_style=guide_style)
+    
+    def display_dict(self, data: Dict[str, Any], title: Optional[str] = None) -> None:
+        """Display a dictionary in a formatted table."""
+        table = self.create_table(title=title)
+        table.add_column("Key", style="cyan", no_wrap=True)
+        table.add_column("Value", style="white")
+        
+        for key, value in data.items():
+            table.add_row(str(key), str(value))
+        
+        self._console.print(table)
+    
+    def display_list(self, items: List[Any], title: Optional[str] = None, 
+                    columns: Optional[List[str]] = None) -> None:
+        """Display a list in a formatted table."""
+        if not items:
+            self.info("No items to display")
+            return
+        
+        table = self.create_table(title=title)
+        
+        if columns:
+            for col in columns:
+                table.add_column(col)
+        else:
+            table.add_column("Item")
+        
+        for item in items:
+            if isinstance(item, (list, tuple)) and columns:
+                table.add_row(*[str(elem) for elem in item])
+            else:
+                table.add_row(str(item))
+        
+        self._console.print(table)
+    
+    def code_block(self, code: str, language: str = "python", title: Optional[str] = None) -> None:
+        """Display a syntax-highlighted code block."""
+        syntax = Syntax(code, language, theme="monokai", line_numbers=True)
+        if title:
+            self._console.print(self.create_panel(syntax, title=title))
+        else:
+            self._console.print(syntax)
+    
+    def markdown(self, text: str) -> None:
+        """Display markdown formatted text."""
+        md = Markdown(text)
+        self._console.print(md)
+
+
+def get_console() -> GentraceConsole:
+    """Get the singleton GentraceConsole instance."""
+    return GentraceConsole()
+
+
+def pretty_print_json(data: Any, title: Optional[str] = None) -> None:
+    """Pretty print JSON data with syntax highlighting."""
+    console = get_console()
+    json_str = json.dumps(data, indent=2)
+    console.code_block(json_str, language="json", title=title)
+
+
+def pretty_print_error(error: Exception, show_traceback: bool = True) -> None:
+    """Pretty print an error with optional traceback."""
+    console = get_console()
+    
+    error_panel = Panel(
+        str(error),
+        title=f"[red]{type(error).__name__}[/red]",
+        border_style="red",
+        title_align="left",
+    )
+    console.console.print(error_panel)
+    
+    if show_traceback:
+        import traceback
+        tb = traceback.format_exc()
+        console.code_block(tb, language="python", title="Traceback")
+
+
+class ProgressHandler:
+    """Handler for progress tracking with rich output."""
+    
+    def __init__(self, total: Optional[int] = None, description: str = "Processing..."):
+        self.console = get_console()
+        self.progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn() if total else TextColumn(""),
+            TimeElapsedColumn(),
+            console=self.console.console,
+            transient=True,
+        )
+        self.task_id: Optional[TaskID] = None
+        self.total = total
+        self.description = description
+        self._started = False
+    
+    def __enter__(self) -> 'ProgressHandler':
+        self.start()
+        return self
+    
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.stop()
+    
+    def start(self) -> None:
+        """Start the progress display."""
+        if not self._started:
+            self.progress.start()
+            self.task_id = self.progress.add_task(self.description, total=self.total)
+            self._started = True
+    
+    def update(self, advance: int = 1, description: Optional[str] = None) -> None:
+        """Update progress."""
+        if self.task_id is not None:
+            if description:
+                self.progress.update(self.task_id, description=description)
+            self.progress.update(self.task_id, advance=advance)
+    
+    def stop(self) -> None:
+        """Stop the progress display."""
+        if self._started:
+            self.progress.stop()
+            self._started = False
+
+
+def display_table(
+    columns: Sequence[Union[Column, str]],
+    rows: Sequence[Sequence[Union[Text, str]]],
+    title: Optional[str] = None,
+    caption: Optional[str] = None,
+    show_lines: bool = False,
+    show_edge: bool = True,
+) -> None:
+    """Display data in a beautifully formatted table."""
+    console = get_console()
+    
+    table = Table(
+        title=title,
+        caption=caption,
+        show_lines=show_lines,
+        show_edge=show_edge,
+        show_header=True,
+        header_style="bold magenta",
+    )
+    
+    # Add columns
+    for col in columns:
+        if isinstance(col, str):
+            table.add_column(col)
+        else:
+            # Assume it's a Column object
+            table.add_column(str(col))
+    
+    # Add rows
+    for row in rows:
+        table.add_row(*[str(cell) for cell in row])
+    
+    console.console.print(table)
+
+
+def format_timestamp(timestamp: Union[int, float, datetime], relative: bool = False) -> str:
+    """Format a timestamp for display."""
+    if isinstance(timestamp, (int, float)):
+        dt = datetime.fromtimestamp(timestamp)
+    else:
+        dt = timestamp
+    
+    if relative:
+        # Calculate relative time
+        now = datetime.now()
+        delta = now - dt
+        
+        if delta.days > 0:
+            return f"{delta.days}d ago"
+        elif delta.seconds > 3600:
+            return f"{delta.seconds // 3600}h ago"
+        elif delta.seconds > 60:
+            return f"{delta.seconds // 60}m ago"
+        else:
+            return "just now"
+    else:
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+
 
 def check_otel_config_and_warn() -> None:
     """
     Checks if a proper OpenTelemetry SDK TracerProvider is configured.
-    If not, issues a warning using `rich` for hyperlink formatting.
+    If not, issues a warning using `rich` for hyperlink formatting and displays
+    formatted OTEL starter code that can be used directly.
     The warning is issued only once per Python session.
     """
     global _otel_config_warning_issued
@@ -37,28 +320,77 @@ def check_otel_config_and_warn() -> None:
         otel_setup_url = "https://github.com/gentrace/gentrace-python/blob/main/README.md#opentelemetry-integration"
         link_text = "Gentrace OpenTelemetry Setup Guide"
 
+        # OTEL starter code that users can copy and use directly
+        otel_starter_code = '''import os
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+# Set up the resource with service name
+resource = Resource(attributes={"service.name": "your-service-name"})
+
+# Create and set the tracer provider
+trace.set_tracer_provider(TracerProvider(resource=resource))
+
+# Configure the OTLP exporter for Gentrace
+otlp_headers = {"Authorization": f"Bearer {os.getenv('GENTRACE_API_KEY')}"}
+span_exporter = OTLPSpanExporter(
+    endpoint=f"{os.getenv('GENTRACE_BASE_URL', 'https://gentrace.ai')}/otel/v1/traces",
+    headers=otlp_headers
+)
+
+# Add the span processor
+trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
+
+print("OpenTelemetry SDK started – spans will be sent to Gentrace.")'''
+
+        console = get_console()
+        
+        # Create a warning panel with rich formatting
+        warning_content = Group(
+            Text("OpenTelemetry SDK (TracerProvider) does not appear to be configured.", style="yellow"),
+            Text(),
+            Text("Gentrace tracing features may not record data:"),
+            Text("  • @interaction", style="on grey30"),
+            Text("  • @eval", style="on grey30"),
+            Text("  • @traced", style="on grey30"),
+            Text("  • eval_dataset()", style="on grey30"),
+            Text(),
+            Text("Please ensure OpenTelemetry is set up as per the:"),
+            Text(link_text, style=f"underline #90EE90 link {otel_setup_url}"),
+        )
+        
+        warning_panel = Panel(
+            warning_content,
+            title="[yellow]⚠ Gentrace Configuration Warning[/yellow]",
+            border_style="yellow",
+            title_align="left",
+            padding=(1, 2),
+        )
+        
         try:
-            # Primary warning mechanism using rich for hyperlink support
-            message = Text()
-            message.append(
-                "Gentrace: OpenTelemetry SDK (TracerProvider) does not appear to be configured. ", style="yellow"
+            console.console.print(warning_panel)
+            console.console.print()  # Add spacing
+            
+            # Display the formatted OTEL starter code
+            console.console.print(Text("Here's the OTEL starter code you can use:", style="bold cyan"))
+            console.console.print()
+            
+            syntax = Syntax(
+                otel_starter_code,
+                "python",
+                theme="monokai",
+                line_numbers=True,
+                word_wrap=True,
+                background_color="default"
             )
-            message.append("Gentrace tracing features (e.g., ")
-            message.append("@interaction", style="on grey30")
-            message.append(", ")
-            message.append("@eval", style="on grey30")
-            message.append(", ")
-            message.append("@traced", style="on grey30")
-            message.append(", and ")
-            message.append("eval_dataset()", style="on grey30")
-            message.append(") may not record data. ")
-            message.append("Please ensure OpenTelemetry is set up as per the ")
-            message.append(link_text, style=f"underline #90EE90 link {otel_setup_url}")
-            message.append(".")
-
-            console = Console(stderr=True, highlight=False)
-            console.print(message)
-
+            console.console.print(syntax)
+            console.console.print()
+            
+            console.console.print(Text("💡 Copy the code above and add it to your application startup.", style="bold green"))
+            
         except Exception:  # Fallback if rich formatting/printing fails
             fallback_message = (
                 f"Gentrace: OpenTelemetry SDK (TracerProvider) does not appear to be configured. "
@@ -188,10 +520,96 @@ def is_pydantic_v1() -> bool:
         return False
 
 
+# Additional pretty printing utilities
+
+def create_status_spinner(text: str = "Processing...", spinner_style: str = DEFAULT_SPINNER) -> Live:
+    """Create a live status spinner that can be updated."""
+    console = get_console()
+    spinner = Spinner(spinner_style, text, style="blue")
+    return Live(spinner, console=console.console, transient=True)
+
+
+def print_trace_info(trace_id: str, span_id: str, parent_span_id: Optional[str] = None) -> None:
+    """Pretty print trace information."""
+    console = get_console()
+    
+    trace_info = {
+        "Trace ID": trace_id,
+        "Span ID": span_id,
+        "Parent Span ID": parent_span_id or "None",
+    }
+    
+    console.display_dict(trace_info, title="Trace Information")
+
+
+def print_evaluation_results(results: Dict[str, Any], title: str = "Evaluation Results") -> None:
+    """Pretty print evaluation results with formatting."""
+    console = get_console()
+    
+    # Create a tree for hierarchical display
+    tree = console.create_tree(f"[bold blue]{title}[/bold blue]")
+    
+    for key, value in results.items():
+        if isinstance(value, dict):
+            subtree = tree.add(f"[cyan]{key}[/cyan]")
+            for sub_k, sub_v in value.items():
+                subtree.add(f"[green]{sub_k}[/green]: {sub_v}")
+        else:
+            tree.add(f"[green]{key}[/green]: {value}")
+    
+    console.console.print(tree)
+
+
+def print_function_call_summary(
+    function_name: str,
+    args: "tuple[Any, ...]",
+    kwargs: "dict[str, Any]",
+    result: Any = None,
+    duration: Optional[float] = None,
+    error: Optional[Exception] = None,
+) -> None:
+    """Pretty print a function call summary."""
+    console = get_console()
+    
+    # Create panel content
+    content_lines = [
+        f"[bold cyan]Function:[/bold cyan] {function_name}",
+        f"[bold cyan]Arguments:[/bold cyan] {args}",
+        f"[bold cyan]Keyword Arguments:[/bold cyan] {kwargs}",
+    ]
+    
+    if duration is not None:
+        content_lines.append(f"[bold cyan]Duration:[/bold cyan] {duration:.3f}s")
+    
+    if error is not None:
+        content_lines.append(f"[bold red]Error:[/bold red] {type(error).__name__}: {str(error)}")
+        border_style = "red"
+        title = "[red]Function Call Failed[/red]"
+    else:
+        content_lines.append(f"[bold green]Result:[/bold green] {result}")
+        border_style = "green"
+        title = "[green]Function Call Completed[/green]"
+    
+    content = "\n".join(content_lines)
+    panel = console.create_panel(content, title=title, border_style=border_style)
+    console.console.print(panel)
+
+
 __all__ = [
     "gentrace_format_otel_attributes",
     "gentrace_format_otel_value",
     "_gentrace_json_dumps",
     "is_pydantic_v1",
     "check_otel_config_and_warn",
+    "GentraceConsole",
+    "get_console",
+    "pretty_print_json",
+    "pretty_print_error",
+    "ProgressHandler",
+    "display_table",
+    "format_timestamp",
+    "create_status_spinner",
+    "print_trace_info",
+    "print_evaluation_results",
+    "print_function_call_summary",
 ]

--- a/src/gentrace/lib/utils.py
+++ b/src/gentrace/lib/utils.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import warnings
-from typing import Any, Set, Dict, List, Union, Optional, Tuple, cast
+from typing import Any, Set, Dict, List, Tuple, Union, Optional, cast
 from datetime import datetime
 from collections.abc import Sequence
 


### PR DESCRIPTION
### TL;DR

I was inspired by Modal's error messages and NUX that directly emitted helpful code snippets to the terminal for users to copy using `rich`. I mimic that behavior here.

![CleanShot 2025-05-24 at 21.48.20@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MjGxPGDRKUg4bqJ5deei/dc850379-b15d-4664-8311-e4111fbd3148.png)

Added rich console utilities and a new example demonstrating OpenTelemetry warnings.

### What changed?

- Added a new `GentraceConsole` class that provides rich formatting capabilities for console output
- Implemented various utility functions for pretty printing JSON, errors, tables, and progress tracking
- Enhanced the OpenTelemetry configuration warning to display formatted starter code
- Created a new example (`no_otel.py`) that demonstrates what happens when using Gentrace without OpenTelemetry setup

### How to test?

1. Run the new example to see the OpenTelemetry warning in action:
```bash
python examples/no_otel.py
```

2. Use the new console utilities in your code:
```python
from gentrace.lib.utils import get_console, pretty_print_json

console = get_console()
console.info("This is an info message")

data = {"key": "value", "nested": {"a": 1, "b": 2}}
pretty_print_json(data, title="Sample Data")
```

### Why make this change?

This change improves the developer experience by providing better formatted console output and clearer guidance when OpenTelemetry is not configured. The enhanced warnings with starter code make it easier for users to properly set up their environment, while the new console utilities enable more visually appealing and informative output throughout the library.