### PR TITLE
fix: Expand the pypi range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "opentelemetry-sdk >= 1.21.0, < 1.33.0",
     "opentelemetry-exporter-otlp-proto-http >= 1.21.0, < 1.33.0",
     "opentelemetry-instrumentation >= 0.41b0",
-    "opentelemetry-processor-baggage >= 0.45.0b0, < 0.55.0",
+    "opentelemetry-processor-baggage >= 0.45.0b0, < 0.60.0",
 ]
 requires-python = ">= 3.8"
 classifiers = [


### PR DESCRIPTION
### TL;DR

Updated the upper version constraint for opentelemetry-processor-baggage dependency.

### What changed?

Increased the upper version constraint for the `opentelemetry-processor-baggage` dependency from `< 0.55.0` to `< 0.60.0` in the pyproject.toml file, while maintaining the same lower bound of `>= 0.45.0b0`.

### How to test?

1. Install the package with the updated dependency constraints
2. Verify that the package works correctly with newer versions of opentelemetry-processor-baggage (up to but not including 0.60.0)
3. Run the existing test suite to ensure compatibility

### Why make this change?

This change allows the project to work with newer versions of the opentelemetry-processor-baggage library, providing compatibility with more recent releases while maintaining backward compatibility with existing supported versions.