### PR TITLE
fix: Store `otel_setup` configuration in init

### DIFF
--- a/src/gentrace/lib/init.py
+++ b/src/gentrace/lib/init.py
@@ -85,8 +85,10 @@ def init(
     _set_client_instances(sync_g_client, async_g_client)
     
     # Set a global flag to indicate that init() has been called
+    # Also store the otel_setup configuration
     import sys
     setattr(sys.modules['gentrace'], '__gentrace_initialized', True)
+    setattr(sys.modules['gentrace'], '__gentrace_otel_setup_config', otel_setup)
     
     # Configure OpenTelemetry if requested
     if otel_setup is not False:


### PR DESCRIPTION
## PR Description

### TLDR
Store otel_setup configuration from init() to improve warning messages

### Summary
This PR enhances the OpenTelemetry configuration warning system by storing the `otel_setup` parameter value from `init()` and using it to provide more contextual warning messages when OpenTelemetry is not properly configured.

### Key Changes
- Store `otel_setup` configuration value as a module attribute when `init()` is called
- Update warning logic to check the stored configuration before displaying warnings
- Only show warnings if `otel_setup` was explicitly set to `False`
- Improve warning message formatting with Rich panels and styled text
- Add code examples for both recommended (using init) and manual OpenTelemetry setup

### Impact
- `lib/init.py`: Stores additional configuration state
- `lib/utils.py`: Enhanced warning system with better conditional logic and formatting

### Testing Considerations
- Verify warnings only appear when `otel_setup=False` is explicitly set
- Test that no warnings appear when `otel_setup=True` or when init() hasn't been called
- Ensure the stored configuration persists correctly across module usage
- Check that the new Rich-formatted warning displays properly in various terminal environments