### PR TITLE
chore: Add otel_setup configuration in init() and check diff

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ This directory contains simplified examples demonstrating key features of the Ge
 ### LLM Integrations
 - `openai_simple.py` - Simple OpenAI integration with Gentrace tracing
 - `openai_instrumentation.py` - OpenAI with automatic OpenInference instrumentation
+- `openai_agents_instrumentation.py` - OpenAI Agents (Swarm) with OpenInference instrumentation
 - `anthropic_simple.py` - Anthropic Claude integration example
 - `pydantic_ai_simple.py` - Simple Pydantic AI framework integration
 
@@ -23,7 +24,8 @@ This directory contains simplified examples demonstrating key features of the Ge
 1. Install dependencies:
 ```bash
 pip install -e ..
-pip install openai anthropic pydantic-ai  # For LLM examples
+pip install openai anthropic pydantic-ai openai-agents  # For LLM examples
+pip install openinference-instrumentation-openai-agents  # For OpenAI Agents instrumentation
 ```
 
 2. Set environment variables:

--- a/examples/openai_agents_instrumentation.py
+++ b/examples/openai_agents_instrumentation.py
@@ -1,0 +1,80 @@
+"""
+OpenAI Agents instrumentation example using OpenInference with Gentrace.
+
+Shows how to instrument OpenAI Agents SDK with automatic tracing of:
+- Agent conversations and tool calls
+- Agent handoffs between specialized agents
+- Full observability through Gentrace
+"""
+
+import os
+
+from agents import Agent, Runner, function_tool
+from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
+import gentrace
+from gentrace import interaction
+
+# Initialize Gentrace with OpenAI Agents instrumentation
+gentrace.init(
+    api_key=os.getenv("GENTRACE_API_KEY"),
+    base_url=os.getenv("GENTRACE_BASE_URL", "https://gentrace.ai/api"),
+    otel_setup={
+        "service_name": "openai-agents-demo",
+        "instrumentations": [OpenAIAgentsInstrumentor()],
+    },
+)
+
+
+@function_tool
+def check_weather(city: str) -> str:
+    """Get current weather for a city (simulated)."""
+    # Simulated weather data
+    weather_data = {
+        "san francisco": "☁️ 62°F, cloudy",
+        "new york": "☀️ 75°F, sunny",
+        "london": "🌧️ 55°F, rainy",
+    }
+    return weather_data.get(city.lower(), f"No weather data for {city}")
+
+
+@function_tool
+def book_flight(from_city: str, to_city: str, date: str) -> str:
+    """Book a flight (simulated)."""
+    return f"✈️ Flight booked from {from_city} to {to_city} on {date}. Confirmation: FL-{hash(from_city + to_city) % 10000}"
+
+
+# Create travel agent with tools
+travel_agent = Agent(
+    name="Travel Assistant",
+    instructions="You are a helpful travel agent. You can check weather and book flights for customers.",
+    tools=[check_weather, book_flight],
+)
+
+
+@interaction(name="travel_planning", pipeline_id=os.getenv("GENTRACE_PIPELINE_ID", ""))
+def plan_trip(request: str) -> str:
+    """Handle a travel planning request - automatically traced."""
+    result = Runner.run_sync(
+        starting_agent=travel_agent,
+        input=request,
+    )
+    return str(result.final_output)
+
+
+def main() -> None:
+    """Run example with automatic tracing."""
+    print("=== OpenAI Agents + OpenInference Example ===\n")
+    
+    # Single request that uses multiple tools
+    response = plan_trip(
+        "I want to fly from San Francisco to New York next Monday. What's the weather like in both cities?"
+    )
+    print(f"Response: {response}")
+    
+    print("\n✓ Agent conversation and tool calls have been traced!")
+    print("Check your Gentrace dashboard to see the full trace.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ openai = [
     "openai",
     "openinference-instrumentation-openai",
 ]
+openai-agents = [
+    "openai-agents>=0.0.19",
+    "openinference-instrumentation-openai-agents",
+]
 anthropic = ["anthropic"]
 pydantic-ai = ["pydantic-ai>=0.2.14"]
 

--- a/src/gentrace/lib/init.py
+++ b/src/gentrace/lib/init.py
@@ -79,10 +79,11 @@ def init(
     _set_client_instances(sync_g_client, async_g_client)
 
     # Set a global flag to indicate that init() has been called
+    # Also store the otel_setup configuration
     import sys
-
     setattr(sys.modules["gentrace"], "__gentrace_initialized", True)
-
+    setattr(sys.modules["gentrace"], "__gentrace_otel_setup_config", otel_setup)
+    
     # Configure OpenTelemetry if requested
     if otel_setup is not False:
         # Extract OpenTelemetry configuration options


### PR DESCRIPTION
## TLDR
Store otel_setup configuration in init() and improve warning messages for unconfigured OpenTelemetry

## Summary
This PR enhances the Gentrace initialization process by storing the `otel_setup` configuration parameter and improving the warning system when OpenTelemetry is not properly configured. The changes provide better user guidance with formatted warnings and code examples.

## Key Changes
- Store `otel_setup` configuration value as a module attribute during init()
- Enhanced warning logic to only show warnings when `otel_setup` is explicitly set to False
- Replaced simple warning messages with rich-formatted panels using the Rich library
- Added code examples for both recommended init() usage and manual OpenTelemetry setup

## Impact
- `init.py`: Modified to store otel_setup configuration
- `utils.py`: Updated warning system with improved formatting and conditional logic
- User experience: Better guidance when OpenTelemetry is not configured

## Testing Considerations
- Test init() with various otel_setup values (True, False, dict, None)
- Verify warning only appears when otel_setup is explicitly False
- Check that rich-formatted warnings display correctly in different terminals
- Ensure backward compatibility with existing initialization patterns
