### PR TITLE
chore: Add Agent.instrument_all() call for tracing

### DIFF
--- a/examples/pydantic_ai_simple.py
+++ b/examples/pydantic_ai_simple.py
@@ -13,6 +13,8 @@ from pydantic_ai.models.openai import OpenAIModel
 import gentrace
 from gentrace import interaction
 
+Agent.instrument_all()
+
 # Initialize Gentrace (will capture Pydantic AI's OTEL traces)
 gentrace.init(
     api_key=os.getenv("GENTRACE_API_KEY"),


### PR DESCRIPTION
## PR Description

### TLDR
Adds Agent.instrument_all() to enable tracing in Pydantic AI example

### Summary
This PR adds instrumentation to the Pydantic AI simple example to enable proper tracing of agent operations through OpenTelemetry.

### Key Changes
- Added `Agent.instrument_all()` call before Gentrace initialization in the example script
- Ensures Pydantic AI's OpenTelemetry traces are properly captured

### Impact
- Affects only the `examples/pydantic_ai_simple.py` file
- No changes to core functionality or other examples

### Testing Considerations
- Verify that Pydantic AI traces are now properly captured in Gentrace
- Ensure the example runs without errors with the new instrumentation
- Check that trace data includes agent-specific operations