### PR TITLE
feat: Add LangChain example with Gentrace instrumentation

### DIFF
--- a/examples/langchain_simple.py
+++ b/examples/langchain_simple.py
@@ -1,0 +1,69 @@
+"""Simple LangChain example with Gentrace instrumentation using OpenInference."""
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false
+# mypy: ignore-errors
+
+import os
+
+from dotenv import load_dotenv
+
+# LangChain imports
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from openinference.instrumentation.langchain import LangChainInstrumentor
+
+import gentrace
+
+load_dotenv()
+
+# Initialize Gentrace with LangChain instrumentation
+gentrace.init(
+    api_key=os.getenv("GENTRACE_API_KEY"),
+    base_url=os.getenv("GENTRACE_BASE_URL", "https://api.gentrace.ai"),
+    otel_setup={"service_name": "langchain-example", "instrumentations": [LangChainInstrumentor()]},
+)
+
+
+def main() -> None:
+    """Run a simple LangChain example with pipeline tracking."""
+    # Check if we have the required environment variables
+    if not os.getenv("OPENAI_API_KEY"):
+        print("Please set OPENAI_API_KEY environment variable")
+        return
+
+    if not os.getenv("GENTRACE_API_KEY"):
+        print("Please set GENTRACE_API_KEY environment variable")
+        return
+
+    # Create components
+    llm = ChatOpenAI(model="gpt-4.1", temperature=0)
+
+    prompt = ChatPromptTemplate.from_messages(
+        [("system", "You are a helpful assistant that explains technical concepts simply."), ("human", "{topic}")]
+    )
+
+    # Create chain
+    chain = prompt | llm | StrOutputParser()
+
+    # Run the chain with pipeline tracking if GENTRACE_PIPELINE_ID is set
+    pipeline_id = os.getenv("GENTRACE_PIPELINE_ID")
+    if pipeline_id:
+        # Wrap with pipeline tracking
+        @gentrace.interaction(pipeline_id=pipeline_id)
+        def run_chain() -> str:
+            result = chain.invoke({"topic": "What is OpenTelemetry?"})
+            print(f"Response: {result}")
+            return result
+
+        run_chain()
+
+    else:
+        # Run without pipeline tracking
+        result = chain.invoke({"topic": "What is OpenTelemetry?"})
+        print(f"Response: {result}")
+
+    print("\nCheck your Gentrace dashboard for traces!")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ openai-agents = [
 ]
 anthropic = ["anthropic"]
 pydantic-ai = ["pydantic-ai>=0.2.14"]
+langchain = [
+    "langchain-core>=0.1.0",
+    "openinference-instrumentation-langchain>=0.1.0",
+]
 
 [tool.rye]
 managed = true
@@ -72,6 +76,10 @@ dev-dependencies = [
     "rich>=13.7.1",
     "nest_asyncio==1.6.0",
     "python-dotenv>=1.0.0",
+    "langchain-core>=0.3.68",
+    "langchain-openai>=0.3.27",
+    "langchain>=0.3.26",
+    "openinference-instrumentation-langchain>=0.1.46",
 ]
 
 [tool.rye.scripts]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -27,6 +27,8 @@ anyio==4.9.0
 argcomplete==3.6.2
     # via nox
     # via pydantic-ai-slim
+async-timeout==4.0.3
+    # via langchain
 boto3==1.38.29
     # via pydantic-ai-slim
 botocore==1.38.29
@@ -83,6 +85,7 @@ google-genai==1.18.0
 googleapis-common-protos==1.70.0
     # via opentelemetry-exporter-otlp-proto-http
 griffe==1.7.3
+    # via openai-agents
     # via pydantic-ai-slim
 groq==0.26.0
     # via pydantic-ai-slim
@@ -98,6 +101,7 @@ httpx==0.28.1
     # via gentrace-py
     # via google-genai
     # via groq
+    # via langsmith
     # via mistralai
     # via openai
     # via pydantic-ai-slim
@@ -121,6 +125,22 @@ jiter==0.9.0
 jmespath==1.0.1
     # via boto3
     # via botocore
+jsonpatch==1.33
+    # via langchain-core
+jsonpointer==3.0.0
+    # via jsonpatch
+langchain==0.3.26
+langchain-core==0.3.68
+    # via gentrace-py
+    # via langchain
+    # via langchain-openai
+    # via langchain-text-splitters
+langchain-openai==0.3.27
+langchain-text-splitters==0.3.8
+    # via langchain
+langsmith==0.4.4
+    # via langchain
+    # via langchain-core
 logfire-api==3.17.0
     # via pydantic-evals
     # via pydantic-graph
@@ -137,20 +157,34 @@ nest-asyncio==1.6.0
 nodeenv==1.8.0
     # via pyright
 nox==2023.4.22
-openai==1.78.1
+openai==1.93.0
     # via gentrace-py
+    # via langchain-openai
+    # via openai-agents
     # via pydantic-ai-slim
+openai-agents==0.1.0
+    # via gentrace-py
 openinference-instrumentation==0.1.34
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
+openinference-instrumentation-langchain==0.1.46
+    # via gentrace-py
 openinference-instrumentation-openai==0.1.30
+    # via gentrace-py
+openinference-instrumentation-openai-agents==1.0.0
     # via gentrace-py
 openinference-semantic-conventions==0.1.21
     # via openinference-instrumentation
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
 opentelemetry-api==1.32.1
     # via fasta2a
     # via openinference-instrumentation
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
     # via opentelemetry-exporter-otlp-proto-http
     # via opentelemetry-instrumentation
     # via opentelemetry-processor-baggage
@@ -163,7 +197,9 @@ opentelemetry-exporter-otlp-proto-http==1.32.1
     # via gentrace-py
 opentelemetry-instrumentation==0.53b1
     # via gentrace-py
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
 opentelemetry-processor-baggage==0.54b0
     # via gentrace-py
 opentelemetry-proto==1.32.1
@@ -175,11 +211,17 @@ opentelemetry-sdk==1.32.1
     # via opentelemetry-exporter-otlp-proto-http
     # via opentelemetry-processor-baggage
 opentelemetry-semantic-conventions==0.53b1
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
     # via opentelemetry-instrumentation
     # via opentelemetry-sdk
+orjson==3.10.18
+    # via langsmith
 packaging==23.2
     # via huggingface-hub
+    # via langchain-core
+    # via langsmith
     # via nox
     # via opentelemetry-instrumentation
     # via pytest
@@ -204,8 +246,12 @@ pydantic==2.10.3
     # via gentrace-py
     # via google-genai
     # via groq
+    # via langchain
+    # via langchain-core
+    # via langsmith
     # via mistralai
     # via openai
+    # via openai-agents
     # via pydantic-ai-slim
     # via pydantic-evals
     # via pydantic-graph
@@ -236,13 +282,24 @@ pytz==2023.3.post1
     # via dirty-equals
 pyyaml==6.0.2
     # via huggingface-hub
+    # via langchain
+    # via langchain-core
     # via pydantic-evals
+regex==2024.11.6
+    # via tiktoken
 requests==2.32.3
     # via cohere
     # via google-genai
     # via huggingface-hub
+    # via langchain
+    # via langsmith
+    # via openai-agents
     # via opentelemetry-exporter-otlp-proto-http
     # via pydantic-ai-slim
+    # via requests-toolbelt
+    # via tiktoken
+requests-toolbelt==1.0.0
+    # via langsmith
 respx==0.22.0
 rich==14.0.0
     # via gentrace-py
@@ -263,8 +320,14 @@ sniffio==1.3.0
     # via gentrace-py
     # via groq
     # via openai
+sqlalchemy==2.0.41
+    # via langchain
 starlette==0.47.0
     # via fasta2a
+tenacity==9.1.2
+    # via langchain-core
+tiktoken==0.9.0
+    # via langchain-openai
 time-machine==2.9.0
 tokenizers==0.21.1
     # via cohere
@@ -277,6 +340,7 @@ tqdm==4.67.1
     # via openai
 types-requests==2.31.0.6
     # via cohere
+    # via openai-agents
 types-urllib3==1.26.25.14
     # via types-requests
 typing-extensions==4.12.2
@@ -287,14 +351,18 @@ typing-extensions==4.12.2
     # via google-genai
     # via groq
     # via huggingface-hub
+    # via langchain-core
     # via mypy
     # via openai
+    # via openai-agents
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
     # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
     # via pyright
     # via rich
+    # via sqlalchemy
     # via starlette
     # via typing-inspection
 typing-inspection==0.4.1
@@ -312,8 +380,12 @@ websockets==15.0.1
     # via google-genai
 wrapt==1.17.2
     # via deprecated
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
     # via opentelemetry-instrumentation
     # via opentelemetry-processor-baggage
 zipp==3.17.0
     # via importlib-metadata
+zstandard==0.23.0
+    # via langsmith

--- a/requirements.lock
+++ b/requirements.lock
@@ -75,6 +75,7 @@ google-genai==1.18.0
 googleapis-common-protos==1.70.0
     # via opentelemetry-exporter-otlp-proto-http
 griffe==1.7.3
+    # via openai-agents
     # via pydantic-ai-slim
 groq==0.26.0
     # via pydantic-ai-slim
@@ -90,6 +91,7 @@ httpx==0.28.1
     # via gentrace-py
     # via google-genai
     # via groq
+    # via langsmith
     # via mistralai
     # via openai
     # via pydantic-ai-slim
@@ -110,6 +112,14 @@ jiter==0.9.0
 jmespath==1.0.1
     # via boto3
     # via botocore
+jsonpatch==1.33
+    # via langchain-core
+jsonpointer==3.0.0
+    # via jsonpatch
+langchain-core==0.3.68
+    # via gentrace-py
+langsmith==0.4.4
+    # via langchain-core
 logfire-api==3.17.0
     # via pydantic-evals
     # via pydantic-graph
@@ -119,20 +129,33 @@ mdurl==0.1.2
     # via markdown-it-py
 mistralai==1.8.1
     # via pydantic-ai-slim
-openai==1.78.1
+openai==1.93.0
     # via gentrace-py
+    # via openai-agents
     # via pydantic-ai-slim
+openai-agents==0.1.0
+    # via gentrace-py
 openinference-instrumentation==0.1.34
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
+openinference-instrumentation-langchain==0.1.46
+    # via gentrace-py
 openinference-instrumentation-openai==0.1.30
+    # via gentrace-py
+openinference-instrumentation-openai-agents==1.0.0
     # via gentrace-py
 openinference-semantic-conventions==0.1.21
     # via openinference-instrumentation
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
 opentelemetry-api==1.32.1
     # via fasta2a
     # via openinference-instrumentation
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
     # via opentelemetry-exporter-otlp-proto-http
     # via opentelemetry-instrumentation
     # via opentelemetry-processor-baggage
@@ -145,7 +168,9 @@ opentelemetry-exporter-otlp-proto-http==1.32.1
     # via gentrace-py
 opentelemetry-instrumentation==0.53b1
     # via gentrace-py
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
 opentelemetry-processor-baggage==0.54b0
     # via gentrace-py
 opentelemetry-proto==1.32.1
@@ -157,11 +182,17 @@ opentelemetry-sdk==1.32.1
     # via opentelemetry-exporter-otlp-proto-http
     # via opentelemetry-processor-baggage
 opentelemetry-semantic-conventions==0.53b1
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
     # via opentelemetry-instrumentation
     # via opentelemetry-sdk
-packaging==25.0
+orjson==3.10.18
+    # via langsmith
+packaging==24.2
     # via huggingface-hub
+    # via langchain-core
+    # via langsmith
     # via opentelemetry-instrumentation
 prompt-toolkit==3.0.51
     # via pydantic-ai-slim
@@ -180,8 +211,11 @@ pydantic==2.10.3
     # via gentrace-py
     # via google-genai
     # via groq
+    # via langchain-core
+    # via langsmith
     # via mistralai
     # via openai
+    # via openai-agents
     # via pydantic-ai-slim
     # via pydantic-evals
     # via pydantic-graph
@@ -204,13 +238,19 @@ python-dateutil==2.9.0.post0
     # via mistralai
 pyyaml==6.0.2
     # via huggingface-hub
+    # via langchain-core
     # via pydantic-evals
 requests==2.32.3
     # via cohere
     # via google-genai
     # via huggingface-hub
+    # via langsmith
+    # via openai-agents
     # via opentelemetry-exporter-otlp-proto-http
     # via pydantic-ai-slim
+    # via requests-toolbelt
+requests-toolbelt==1.0.0
+    # via langsmith
 rich==14.0.0
     # via gentrace-py
     # via pydantic-ai-slim
@@ -229,6 +269,8 @@ sniffio==1.3.0
     # via openai
 starlette==0.47.0
     # via fasta2a
+tenacity==9.1.2
+    # via langchain-core
 tokenizers==0.21.1
     # via cohere
 tomli==2.2.1
@@ -238,6 +280,7 @@ tqdm==4.67.1
     # via openai
 types-requests==2.31.0.6
     # via cohere
+    # via openai-agents
 types-urllib3==1.26.25.14
     # via types-requests
 typing-extensions==4.12.2
@@ -248,8 +291,11 @@ typing-extensions==4.12.2
     # via google-genai
     # via groq
     # via huggingface-hub
+    # via langchain-core
     # via openai
+    # via openai-agents
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
     # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
@@ -269,8 +315,12 @@ websockets==15.0.1
     # via google-genai
 wrapt==1.17.2
     # via deprecated
+    # via openinference-instrumentation-langchain
     # via openinference-instrumentation-openai
+    # via openinference-instrumentation-openai-agents
     # via opentelemetry-instrumentation
     # via opentelemetry-processor-baggage
 zipp==3.21.0
     # via importlib-metadata
+zstandard==0.23.0
+    # via langsmith


### PR DESCRIPTION
## PR Description

### TLDR
Adds LangChain integration example with Gentrace OpenTelemetry instrumentation

### Summary
This PR introduces a new example demonstrating how to use LangChain with Gentrace's OpenTelemetry-based instrumentation. The example shows how to instrument a simple LangChain chain that uses ChatGPT to explain technical concepts, with optional pipeline tracking support.

### Key Changes
- Added `langchain_simple.py` example that demonstrates:
  - Setting up Gentrace with LangChain instrumentation via OpenInference
  - Creating a basic LangChain chain with ChatOpenAI, prompts, and output parsing
  - Optional pipeline tracking using Gentrace's `@interaction` decorator
- Updated `pyproject.toml` to include LangChain dependencies as an optional extra

### Impact
- Adds new optional dependencies for LangChain support
- Provides users with a reference implementation for integrating LangChain with Gentrace
- No changes to existing functionality

### Testing Considerations
- Verify the example runs correctly with required environment variables (`OPENAI_API_KEY`, `GENTRACE_API_KEY`)
- Test both with and without `GENTRACE_PIPELINE_ID` set
- Confirm traces appear correctly in the Gentrace dashboard
- Ensure new dependencies install correctly when using the `langchain` extra