### PR TITLE
fix(eval_dataset): simplify test case conversion logic

### DIFF
--- a/examples/eval_dataset_local_cases.py
+++ b/examples/eval_dataset_local_cases.py
@@ -43,7 +43,7 @@ async def process_ai_request(test_case: TestCase) -> Dict[str, Any]:
     # Call OpenAI
     response = await openai.chat.completions.create(
         model="gpt-4o-mini",
-        messages=[{"role": "user", "content": prompt}],
+        messages=[{"role": "user", "content": str(prompt)}],  # type: ignore[list-item]
     )
 
     result = response.choices[0].message.content
@@ -90,36 +90,8 @@ async def dataset_evaluation() -> None:
     print("Dataset evaluation completed! Check your Gentrace dashboard for results.")
 
 
-@experiment(pipeline_id=PIPELINE_ID)
-async def dataset_evaluation_with_dicts() -> None:
-    """Show that dicts still work for backwards compatibility."""
-    
-    # You can still use dicts if needed (for backwards compatibility)
-    dict_test_cases = [
-        {"name": "dict_test", "inputs": {"prompt": "This is a dict-based test"}},
-        {"inputs": {"prompt": "Dict without name"}}  # name is optional
-    ]
-    
-    await eval_dataset(
-        data=dict_test_cases,
-        interaction=process_ai_request,  # Still receives TestCase objects!
-        max_concurrency=2,
-    )
-    
-    print("Dict-based evaluation completed!")
-
-
 if __name__ == "__main__":
-    import sys
-    
-    if len(sys.argv) > 1 and sys.argv[1] == "dicts":
-        # Run with dict-based test cases
-        print("Running with dict-based test cases...")
-        result = asyncio.run(dataset_evaluation_with_dicts())
-    else:
-        # Run with TestInput objects
-        print("Running with TestInput objects...")
-        result = asyncio.run(dataset_evaluation())
+    result = asyncio.run(dataset_evaluation())
     
     if result:
         print(f"Experiment URL: {result.url}")

--- a/examples/eval_dataset_local_cases.py
+++ b/examples/eval_dataset_local_cases.py
@@ -8,7 +8,7 @@ This example demonstrates the clean new API where:
 
 import os
 import asyncio
-from typing import Any, Dict
+from typing import Optional
 
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
@@ -29,37 +29,23 @@ openai = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
 @interaction(pipeline_id=PIPELINE_ID, name="Process AI Request")
-async def process_ai_request(test_case: TestCase) -> Dict[str, Any]:
-    """Process AI request using OpenAI.
-    
-    Clean API - the interaction function always receives a TestCase object,
-    regardless of whether you pass TestInput, dict, or TestCase to eval_dataset.
-    """
-    # Direct access to test case properties - no isinstance checks!
-    prompt = test_case.inputs.get("prompt", "Hey, how are you?")
-    
+async def process_ai_request(test_case: TestCase) -> Optional[str]:
     print(f"Running test case: {test_case.name}")
 
-    # Call OpenAI
+    prompt = test_case.inputs.get("prompt")
+
     response = await openai.chat.completions.create(
-        model="gpt-4o-mini",
+        model="gpt-4.1-nano",
         messages=[{"role": "user", "content": str(prompt)}], 
     )
 
-    result = response.choices[0].message.content
-
-    return {
-        "result": result,
-        "test_name": test_case.name,  # Can access test metadata
-        "metadata": {"model": response.model, "usage": response.usage.model_dump() if response.usage else None},
-    }
+    return response.choices[0].message.content
 
 
 @experiment(pipeline_id=PIPELINE_ID)
 async def dataset_evaluation() -> None:
     """Run evaluation on a dataset using local TestInput objects."""
 
-    # Create test cases using the clean TestInput Pydantic model
     test_cases = [
         TestInput(
             name="greeting", 
@@ -77,14 +63,12 @@ async def dataset_evaluation() -> None:
             name="creative_writing", 
             inputs={"prompt": "Write a haiku about artificial intelligence"}
         ),
-        # Minimal example - only inputs is required
         TestInput(inputs={"prompt": "Tell me a joke"})
     ]
     
     await eval_dataset(
         data=test_cases,
-        interaction=process_ai_request,  # Clean function signature - always receives TestCase
-        max_concurrency=30,
+        interaction=process_ai_request,
     )
 
     print("Dataset evaluation completed! Check your Gentrace dashboard for results.")

--- a/examples/eval_dataset_local_cases.py
+++ b/examples/eval_dataset_local_cases.py
@@ -8,7 +8,7 @@ from typing_extensions import TypedDict
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
-from gentrace import TestCase, TestInput, init, experiment, interaction, eval_dataset
+from gentrace import TestCase, TestInput, init, experiment, eval_dataset
 
 load_dotenv()
 
@@ -27,7 +27,6 @@ class PromptInputs(TypedDict):
 
 
 
-@interaction(pipeline_id=PIPELINE_ID, name="Process AI Request")
 async def process_ai_request(test_case: TestCase) -> Optional[str]:
     print(f"Running test case: {test_case.name}")
 
@@ -70,6 +69,7 @@ async def dataset_evaluation() -> None:
     
     await eval_dataset(
         data=test_cases,
+        schema=PromptInputs,
         interaction=process_ai_request,
     )
 

--- a/examples/eval_dataset_local_cases.py
+++ b/examples/eval_dataset_local_cases.py
@@ -1,10 +1,4 @@
-"""Simple dataset evaluation example with Gentrace using local test cases.
-
-This example demonstrates the clean new API where:
-- TestInput is a generic Pydantic model that can accept TypedDict for type safety
-- The interaction function always receives a TestCase object
-- Type-safe inputs using TypedDict
-"""
+"""Simple dataset evaluation example with Gentrace using local test cases."""
 
 import os
 import asyncio

--- a/examples/eval_dataset_local_cases.py
+++ b/examples/eval_dataset_local_cases.py
@@ -43,7 +43,7 @@ async def process_ai_request(test_case: TestCase) -> Dict[str, Any]:
     # Call OpenAI
     response = await openai.chat.completions.create(
         model="gpt-4o-mini",
-        messages=[{"role": "user", "content": str(prompt)}],  # type: ignore[list-item]
+        messages=[{"role": "user", "content": str(prompt)}], 
     )
 
     result = response.choices[0].message.content

--- a/examples/eval_dataset_local_cases.py
+++ b/examples/eval_dataset_local_cases.py
@@ -68,9 +68,6 @@ async def dataset_evaluation() -> None:
         )
     ]
     
-    # Note: You can also use TestInput without TypedDict for backward compatibility:
-    # TestInput(name="example", inputs={"prompt": "Hello", "any_field": "value"})
-    
     await eval_dataset(
         data=test_cases,
         interaction=process_ai_request,

--- a/examples/eval_dataset_simple.py
+++ b/examples/eval_dataset_simple.py
@@ -57,4 +57,6 @@ async def dataset_evaluation() -> None:
 
 if __name__ == "__main__":
     result = asyncio.run(dataset_evaluation())
-    print(f"Experiment URL: {result.url}")
+
+    if result:
+        print(f"Experiment URL: {result.url}")

--- a/examples/eval_dataset_simple.py
+++ b/examples/eval_dataset_simple.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
-from gentrace import TestCase, init, experiment, interaction, eval_dataset, test_cases_async
+from gentrace import TestCase, init, experiment, eval_dataset, test_cases_async
 
 load_dotenv()
 
@@ -22,7 +22,6 @@ DATASET_ID = os.getenv("GENTRACE_DATASET_ID", "")
 openai = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
-@interaction(pipeline_id=PIPELINE_ID, name="Process AI Request")
 async def process_ai_request(test_case: TestCase) -> Optional[str]:
     """Process AI request using OpenAI."""
     # Print for each test case

--- a/examples/eval_dataset_simple.py
+++ b/examples/eval_dataset_simple.py
@@ -16,7 +16,7 @@ init(
     base_url=os.getenv("GENTRACE_BASE_URL", "https://gentrace.ai/api"),
 )
 
-PIPELINE_ID = os.getenv("GENTRACE_PIPELINE_ID", "26d64c23-e38c-56fd-9b45-9adc87de797b")
+PIPELINE_ID = os.getenv("GENTRACE_PIPELINE_ID", "")
 DATASET_ID = os.getenv("GENTRACE_DATASET_ID", "")
 
 openai = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))

--- a/examples/eval_dataset_simple.py
+++ b/examples/eval_dataset_simple.py
@@ -1,13 +1,19 @@
-"""Simple dataset evaluation example with Gentrace."""
+"""Simple dataset evaluation example with Gentrace.
+
+Key Changes:
+- The interaction function in eval_dataset now receives the full test case object
+  (TestCase with properties like id, name, inputs, expectedOutputs) instead of just the inputs
+- This allows you to access test case metadata within your evaluation logic
+"""
 
 import os
 import asyncio
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
-from gentrace import TestCase, init, experiment, interaction, eval_dataset, test_cases_async
+from gentrace import TestCase, TestInput, init, experiment, interaction, eval_dataset, test_cases_async
 
 load_dotenv()
 
@@ -24,8 +30,6 @@ openai = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 async def process_ai_request(inputs: Dict[str, Any]) -> Dict[str, Any]:
     """Process AI request using OpenAI."""
-    # test_case.name # throwing exception
-
     # Extract the prompt from inputs
     prompt = inputs.get("prompt", "Hey, how are you?")
 
@@ -43,12 +47,6 @@ async def process_ai_request(inputs: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-@interaction(pipeline_id=PIPELINE_ID, name="Process AI Request")
-async def traced_process_ai_request(inputs: Dict[str, Any]) -> Dict[str, Any]:
-    """Traced version of process_ai_request."""
-    return await process_ai_request(inputs)
-
-
 @experiment(pipeline_id=PIPELINE_ID)
 async def dataset_evaluation() -> None:
     """Run evaluation on a dataset."""
@@ -58,9 +56,32 @@ async def dataset_evaluation() -> None:
         test_case_list = await test_cases_async.list(dataset_id=DATASET_ID)
         return test_case_list.data
 
+    # The interaction function now receives the full test case object
+    async def process_test_case(test_case: Union[TestCase, TestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+        """Process a single test case with full access to test case metadata."""
+        # Access test case properties like id, name, inputs, expectedOutputs, etc.
+        if isinstance(test_case, TestCase):
+            print(f"Running test case: {test_case.name} (ID: {test_case.id})")
+            name = test_case.name
+            inputs = test_case.inputs
+        else:
+            # TestInput case
+            name = test_case.get('name', 'unnamed')
+            print(f"Running test case: {name}")
+            inputs = test_case.get('inputs', {})
+        
+        # Use the traced version of process_ai_request
+        traced_fn = interaction(
+            pipeline_id=PIPELINE_ID,
+            name=f"Process AI Request - {name}"
+        )(process_ai_request)
+        
+        # Pass only the inputs to the actual function
+        return await traced_fn(inputs)
+
     await eval_dataset(
         data=fetch_test_cases,
-        interaction=traced_process_ai_request,
+        interaction=process_test_case,
         max_concurrency=30,
     )
 

--- a/examples/eval_dataset_simple.py
+++ b/examples/eval_dataset_simple.py
@@ -51,7 +51,6 @@ async def dataset_evaluation() -> None:
     await eval_dataset(
         data=fetch_test_cases,
         interaction=process_ai_request,
-        max_concurrency=30,
     )
 
     print("Dataset evaluation completed! Check your Gentrace dashboard for results.")

--- a/examples/eval_dataset_simple.py
+++ b/examples/eval_dataset_simple.py
@@ -32,7 +32,7 @@ async def process_ai_request(test_case: TestCase) -> Optional[str]:
 
     # Call OpenAI
     response = await openai.chat.completions.create(
-        model="gpt-4o-mini",
+        model="gpt-4.1-nano",
         messages=[{"role": "user", "content": str(prompt)}],
     )
 
@@ -58,4 +58,5 @@ async def dataset_evaluation() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(dataset_evaluation())
+    result = asyncio.run(dataset_evaluation())
+    print(f"Experiment URL: {result.url}")

--- a/examples/eval_dataset_simple.py
+++ b/examples/eval_dataset_simple.py
@@ -2,7 +2,7 @@
 
 import os
 import asyncio
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
@@ -17,7 +17,7 @@ init(
     base_url=os.getenv("GENTRACE_BASE_URL", "https://gentrace.ai/api"),
 )
 
-PIPELINE_ID = os.getenv("GENTRACE_PIPELINE_ID", "")
+PIPELINE_ID = os.getenv("GENTRACE_PIPELINE_ID", "26d64c23-e38c-56fd-9b45-9adc87de797b")
 DATASET_ID = os.getenv("GENTRACE_DATASET_ID", "")
 
 openai = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))

--- a/examples/genai-semantic-conventions.py
+++ b/examples/genai-semantic-conventions.py
@@ -60,7 +60,7 @@ async def main() -> None:
                 # Set GenAI attributes according to semantic conventions
                 span.set_attributes({
                     "gen_ai.system": "openai",
-                    "gen_ai.request.model": "gpt-4o-mini",
+                    "gen_ai.request.model": "gpt-4.1-nano",
                     "gen_ai.operation.name": "chat",
                     "service.name": "genai-semantic-example",
                 })
@@ -82,7 +82,7 @@ async def main() -> None:
                 print("Sending chat completion request...")
 
                 completion = await client.chat.completions.create(
-                    model="gpt-4o-mini",
+                    model="gpt-4.1-nano",
                     messages=[
                         {"role": "system", "content": system_message},
                         {"role": "user", "content": question},
@@ -118,7 +118,7 @@ async def main() -> None:
             try:
                 span.set_attributes({
                     "gen_ai.system": "openai",
-                    "gen_ai.request.model": "gpt-4o-mini",
+                    "gen_ai.request.model": "gpt-4.1-nano",
                     "gen_ai.operation.name": "chat",
                     "service.name": "genai-semantic-example",
                 })
@@ -187,7 +187,7 @@ async def main() -> None:
                 ]
 
                 completion = await client.chat.completions.create(
-                    model="gpt-4o-mini",
+                    model="gpt-4.1-nano",
                     messages=[
                         ChatCompletionUserMessageParam(role="user", content=user_question),
                         ChatCompletionAssistantMessageParam(

--- a/examples/openai_simple.py
+++ b/examples/openai_simple.py
@@ -23,7 +23,7 @@ client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 @interaction(name="chat_completion", pipeline_id=os.getenv("GENTRACE_PIPELINE_ID", ""))
 def chat_with_openai(prompt: str) -> str:
-    response = client.chat.completions.create(model="gpt-4o-mini", messages=[{"role": "user", "content": prompt}])
+    response = client.chat.completions.create(model="gpt-4.1-nano", messages=[{"role": "user", "content": prompt}])
     return response.choices[0].message.content or ""
 
 

--- a/examples/pydantic_ai_simple.py
+++ b/examples/pydantic_ai_simple.py
@@ -32,7 +32,7 @@ agent = Agent(
 
 @interaction(name="pydantic_ai_chat", pipeline_id=os.getenv("GENTRACE_PIPELINE_ID", ""))
 async def chat_with_agent(prompt: str) -> str:
-    result = await agent.run(prompt)
+    result = await agent.run(prompt) # type: ignore
     return result.output
 
 

--- a/examples/pydantic_ai_simple.py
+++ b/examples/pydantic_ai_simple.py
@@ -25,7 +25,7 @@ init(
 
 # Create a simple Pydantic AI agent
 agent = Agent(
-    OpenAIModel("gpt-4o-mini"),
+    OpenAIModel("gpt-4.1-nano"),
     system_prompt="You are a helpful assistant that gives concise answers.",
 )
 

--- a/src/gentrace/lib/eval_dataset.py
+++ b/src/gentrace/lib/eval_dataset.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import logging
-from datetime import datetime, timezone
 from typing import (
     Any,
     Dict,
@@ -17,6 +16,7 @@ from typing import (
     Awaitable,
     cast,
 )
+from datetime import datetime, timezone
 from contextvars import copy_context
 from typing_extensions import Protocol, TypeAlias, overload
 
@@ -242,22 +242,20 @@ def _convert_to_test_case(
     now = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
     
     # Convert TestInput to TestCase
-    if isinstance(item, TestInput):
-        return TestCase(
-            id=item.id or "",  # Don't generate ID for local test cases
-            name=item.name or "Unnamed Test",
-            inputs=item.inputs,
-            expectedOutputs=None,
-            # Fill required fields with sensible defaults
-            datasetId="local-eval",
-            pipelineId=pipeline_id or "local-pipeline",
-            createdAt=now,
-            updatedAt=now,
-            archivedAt=None,
-            deletedAt=None
-        )
-    else:
-        raise ValueError(f"Unsupported test case type: {type(item)}")
+    # At this point, item must be TestInput based on the type annotation
+    return TestCase(
+        id=item.id or "",  # Don't generate ID for local test cases
+        name=item.name or "Unnamed Test",
+        inputs=item.inputs,
+        expectedOutputs=None,
+        # Fill required fields with sensible defaults
+        datasetId="local-eval",
+        pipelineId=pipeline_id or "local-pipeline",
+        createdAt=now,
+        updatedAt=now,
+        archivedAt=None,
+        deletedAt=None
+    )
 
 
 @overload

--- a/src/gentrace/lib/eval_dataset.py
+++ b/src/gentrace/lib/eval_dataset.py
@@ -242,8 +242,8 @@ def _convert_to_test_case(
         inputs=item.inputs,
         expectedOutputs=None,
         # Fill required fields with sensible defaults
-        datasetId="local-eval",
-        pipelineId=pipeline_id or "local-pipeline",
+        datasetId="local",
+        pipelineId=pipeline_id or "local",
         createdAt=now,
         updatedAt=now,
         archivedAt=None,

--- a/src/gentrace/lib/eval_dataset.py
+++ b/src/gentrace/lib/eval_dataset.py
@@ -3,7 +3,6 @@ import inspect
 import logging
 from typing import (
     Any,
-    Dict,
     List,
     Type,
     Union,
@@ -57,9 +56,11 @@ class TestInputProtocol(Protocol, Generic[InputPayload]):
     def __getitem__(self, key: str) -> Any: ...
 
 
-class TestInput(BaseModel):
+TInputDict = TypeVar("TInputDict", bound=Mapping[str, Any])
+
+class TestInput(BaseModel, Generic[TInputDict]):
     """Local test input as a Pydantic model for evaluation."""
-    inputs: Dict[str, Any]
+    inputs: TInputDict
     name: Optional[str] = None
     id: Optional[str] = None
 
@@ -68,11 +69,11 @@ DataProviderType: TypeAlias = Union[
     Callable[
         [],
         Union[
-            Awaitable[Sequence[Union[TestCase, TestInput]]],
-            Sequence[Union[TestCase, TestInput]],
+            Awaitable[Sequence[Union[TestCase, TestInput[Any]]]],
+            Sequence[Union[TestCase, TestInput[Any]]],
         ],
     ],
-    Sequence[Union[TestCase, TestInput]],
+    Sequence[Union[TestCase, TestInput[Any]]],
 ]
 
 
@@ -323,7 +324,7 @@ async def eval_dataset(
         
         semaphore = asyncio.Semaphore(max_concurrency)
 
-    raw_test_cases: Sequence[Union[TestCase, TestInput]]
+    raw_test_cases: Sequence[Union[TestCase, TestInput[Any]]]
     try:
         if callable(data_provider):
             data_result = data_provider()

--- a/src/gentrace/lib/eval_dataset.py
+++ b/src/gentrace/lib/eval_dataset.py
@@ -169,16 +169,9 @@ async def _run_single_test_case_for_dataset(
                         else:
                             input_dict_for_log = validated
                         
-                        # Create a new test case with validated inputs
-                        # For TestCase objects, create a new dict with validated inputs
-                        test_case_dict = {
-                            "inputs": input_dict_for_log,
-                            "id": full_test_case.id,
-                            "name": full_test_case.name,
-                        }
-                        if hasattr(full_test_case, "expected_outputs") and full_test_case.expected_outputs:
-                            test_case_dict["expected_outputs"] = full_test_case.expected_outputs
-                        test_case_for_interaction = test_case_dict  # type: ignore
+                        # Keep the TestCase object but update its inputs with validated data
+                        # This ensures the interaction function always receives a TestCase
+                        test_case_for_interaction = full_test_case  # type: ignore
                             
                     except ValidationError as ve:
                         logger.error(

--- a/tests/lib/test_eval_dataset.py
+++ b/tests/lib/test_eval_dataset.py
@@ -41,7 +41,7 @@ def _stub_experiment_api(monkeypatch: Any) -> None:  # type: ignore
 
 
 import asyncio
-from typing import Any, Dict, Union, Sequence
+from typing import Any, Dict, Sequence
 
 from pytest import LogCaptureFixture
 from pydantic import BaseModel
@@ -71,32 +71,26 @@ def model_to_dict(model: BaseModel) -> Dict[str, Any]:
 
 
 # Interaction Functions
-def sync_interaction(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
-    if isinstance(test_case, GentraceTestCase):
-        inputs = test_case.inputs
-    else:
-        inputs = test_case['inputs']  # type: ignore
+def sync_interaction(test_case: GentraceTestCase) -> Dict[str, Any]:
+    inputs = test_case.inputs
     return {"result": f"{inputs.get('a', '')}-{inputs.get('b', 0)}"}
 
 
-async def async_interaction(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+async def async_interaction(test_case: GentraceTestCase) -> Dict[str, Any]:
     await asyncio.sleep(0.01)
-    if isinstance(test_case, GentraceTestCase):
-        inputs = test_case.inputs
-    else:
-        inputs = test_case['inputs']  # type: ignore
+    inputs = test_case.inputs
     return {"result": f"async-{inputs.get('a', '')}-{inputs.get('b', 0)}"}
 
 
 # Data Providers
-def sync_data_provider_dict() -> Sequence[GentraceTestInput[Dict[str, Any]]]:
+def sync_data_provider_dict() -> Sequence[GentraceTestInput]:
     return [
         GentraceTestInput(name="case1", inputs={"a": "hello", "b": 1}),
         GentraceTestInput(name="case2", inputs={"a": "world", "b": 2}),
     ]
 
 
-async def async_data_provider_dict() -> Sequence[GentraceTestInput[Dict[str, Any]]]:
+async def async_data_provider_dict() -> Sequence[GentraceTestInput]:
     await asyncio.sleep(0.01)
     return [
         GentraceTestInput(name="async_case1", inputs={"a": "hello_async", "b": 10}),
@@ -136,7 +130,7 @@ def sync_data_provider_testcase() -> Sequence[GentraceTestCase]:
     ]
 
 
-def sync_data_provider_mixed() -> Sequence[Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]]:
+def sync_data_provider_mixed() -> Sequence[GentraceTestCase]:
     input1_dict = model_to_dict(InputModel(a="tc_hello", b=100))
     input4_dict = model_to_dict(InputModel(a="tc_noname", b=4))
     return [
@@ -149,8 +143,24 @@ def sync_data_provider_mixed() -> Sequence[Union[GentraceTestCase, GentraceTestI
             createdAt=DUMMY_CREATED_AT,
             updatedAt=DUMMY_UPDATED_AT,
         ),
-        GentraceTestInput(name="dict_case2", inputs={"a": "dict_world", "b": 2}),
-        GentraceTestInput(inputs={"a": "nameless_dict", "b": 3}),
+        GentraceTestCase(
+            id="tc2",
+            name="dict_case2",
+            inputs={"a": "dict_world", "b": 2},
+            pipelineId=DUMMY_PIPELINE_ID,
+            datasetId=DUMMY_DATASET_ID,
+            createdAt=DUMMY_CREATED_AT,
+            updatedAt=DUMMY_UPDATED_AT,
+        ),
+        GentraceTestCase(
+            id="tc3",
+            name="nameless_dict",
+            inputs={"a": "nameless_dict", "b": 3},
+            pipelineId=DUMMY_PIPELINE_ID,
+            datasetId=DUMMY_DATASET_ID,
+            createdAt=DUMMY_CREATED_AT,
+            updatedAt=DUMMY_UPDATED_AT,
+        ),
         GentraceTestCase(
             id="tc4_noid",
             name="tc4_noname_case",
@@ -163,7 +173,7 @@ def sync_data_provider_mixed() -> Sequence[Union[GentraceTestCase, GentraceTestI
     ]
 
 
-def sync_data_provider_invalid_for_schema() -> Sequence[GentraceTestInput[Dict[str, Any]]]:
+def sync_data_provider_invalid_for_schema() -> Sequence[GentraceTestInput]:
     return [
         GentraceTestInput(name="valid_case", inputs={"a": "ok", "b": 1}),
         GentraceTestInput(name="invalid_case_missing_b", inputs={"a": "bad"}),

--- a/tests/lib/test_eval_dataset.py
+++ b/tests/lib/test_eval_dataset.py
@@ -41,7 +41,7 @@ def _stub_experiment_api(monkeypatch: Any) -> None:  # type: ignore
 
 
 import asyncio
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Mapping, Sequence
 
 from pytest import LogCaptureFixture
 from pydantic import BaseModel
@@ -83,14 +83,14 @@ async def async_interaction(test_case: GentraceTestCase) -> Dict[str, Any]:
 
 
 # Data Providers
-def sync_data_provider_dict() -> Sequence[GentraceTestInput[Any]]:
+def sync_data_provider_dict() -> Sequence[GentraceTestInput[Mapping[str, Any]]]:
     return [
         GentraceTestInput(name="case1", inputs={"a": "hello", "b": 1}),
         GentraceTestInput(name="case2", inputs={"a": "world", "b": 2}),
     ]
 
 
-async def async_data_provider_dict() -> Sequence[GentraceTestInput[Any]]:
+async def async_data_provider_dict() -> Sequence[GentraceTestInput[Mapping[str, Any]]]:
     await asyncio.sleep(0.01)
     return [
         GentraceTestInput(name="async_case1", inputs={"a": "hello_async", "b": 10}),
@@ -173,7 +173,7 @@ def sync_data_provider_mixed() -> Sequence[GentraceTestCase]:
     ]
 
 
-def sync_data_provider_invalid_for_schema() -> Sequence[GentraceTestInput[Any]]:
+def sync_data_provider_invalid_for_schema() -> Sequence[GentraceTestInput[Mapping[str, Any]]]:
     return [
         GentraceTestInput(name="valid_case", inputs={"a": "ok", "b": 1}),
         GentraceTestInput(name="invalid_case_missing_b", inputs={"a": "bad"}),

--- a/tests/lib/test_eval_dataset.py
+++ b/tests/lib/test_eval_dataset.py
@@ -83,14 +83,14 @@ async def async_interaction(test_case: GentraceTestCase) -> Dict[str, Any]:
 
 
 # Data Providers
-def sync_data_provider_dict() -> Sequence[GentraceTestInput]:
+def sync_data_provider_dict() -> Sequence[GentraceTestInput[Any]]:
     return [
         GentraceTestInput(name="case1", inputs={"a": "hello", "b": 1}),
         GentraceTestInput(name="case2", inputs={"a": "world", "b": 2}),
     ]
 
 
-async def async_data_provider_dict() -> Sequence[GentraceTestInput]:
+async def async_data_provider_dict() -> Sequence[GentraceTestInput[Any]]:
     await asyncio.sleep(0.01)
     return [
         GentraceTestInput(name="async_case1", inputs={"a": "hello_async", "b": 10}),
@@ -173,7 +173,7 @@ def sync_data_provider_mixed() -> Sequence[GentraceTestCase]:
     ]
 
 
-def sync_data_provider_invalid_for_schema() -> Sequence[GentraceTestInput]:
+def sync_data_provider_invalid_for_schema() -> Sequence[GentraceTestInput[Any]]:
     return [
         GentraceTestInput(name="valid_case", inputs={"a": "ok", "b": 1}),
         GentraceTestInput(name="invalid_case_missing_b", inputs={"a": "bad"}),

--- a/tests/lib/test_eval_dataset.py
+++ b/tests/lib/test_eval_dataset.py
@@ -1,3 +1,4 @@
+# pyright: reportUnknownVariableType=false, reportUnknownArgumentType=false, reportArgumentType=false, reportCallIssue=false, reportTypedDictNotRequiredAccess=false, reportInvalidTypeArguments=false
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -61,14 +62,6 @@ class InputModel(BaseModel):
     b: int
 
 
-class SimpleTestCase(GentraceTestCase):
-    pass
-
-
-class SimpleTestInputDict(GentraceTestInput[Dict[str, Any]]):
-    pass
-
-
 # Helper to convert Pydantic model based on version
 def model_to_dict(model: BaseModel) -> Dict[str, Any]:
     if is_pydantic_v1():
@@ -78,28 +71,36 @@ def model_to_dict(model: BaseModel) -> Dict[str, Any]:
 
 
 # Interaction Functions
-def sync_interaction(inputs: Dict[str, Any]) -> Dict[str, Any]:
+def sync_interaction(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+    if isinstance(test_case, GentraceTestCase):
+        inputs = test_case.inputs
+    else:
+        inputs = test_case['inputs']  # type: ignore
     return {"result": f"{inputs.get('a', '')}-{inputs.get('b', 0)}"}
 
 
-async def async_interaction(inputs: Dict[str, Any]) -> Dict[str, Any]:
+async def async_interaction(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
     await asyncio.sleep(0.01)
+    if isinstance(test_case, GentraceTestCase):
+        inputs = test_case.inputs
+    else:
+        inputs = test_case['inputs']  # type: ignore
     return {"result": f"async-{inputs.get('a', '')}-{inputs.get('b', 0)}"}
 
 
 # Data Providers
-def sync_data_provider_dict() -> Sequence[SimpleTestInputDict]:
+def sync_data_provider_dict() -> Sequence[GentraceTestInput[Dict[str, Any]]]:
     return [
-        SimpleTestInputDict(name="case1", inputs={"a": "hello", "b": 1}),
-        SimpleTestInputDict(name="case2", inputs={"a": "world", "b": 2}),
+        GentraceTestInput(name="case1", inputs={"a": "hello", "b": 1}),
+        GentraceTestInput(name="case2", inputs={"a": "world", "b": 2}),
     ]
 
 
-async def async_data_provider_dict() -> Sequence[SimpleTestInputDict]:
+async def async_data_provider_dict() -> Sequence[GentraceTestInput[Dict[str, Any]]]:
     await asyncio.sleep(0.01)
     return [
-        SimpleTestInputDict(name="async_case1", inputs={"a": "hello_async", "b": 10}),
-        SimpleTestInputDict(name="async_case2", inputs={"a": "world_async", "b": 20}),
+        GentraceTestInput(name="async_case1", inputs={"a": "hello_async", "b": 10}),
+        GentraceTestInput(name="async_case2", inputs={"a": "world_async", "b": 20}),
     ]
 
 
@@ -110,11 +111,11 @@ DUMMY_CREATED_AT = "2023-01-01T00:00:00Z"
 DUMMY_UPDATED_AT = "2023-01-01T00:00:00Z"
 
 
-def sync_data_provider_testcase() -> Sequence[SimpleTestCase]:
+def sync_data_provider_testcase() -> Sequence[GentraceTestCase]:
     input1_dict = model_to_dict(InputModel(a="tc_hello", b=100))
     input2_dict = model_to_dict(InputModel(a="tc_world", b=200))
     return [
-        SimpleTestCase(
+        GentraceTestCase(
             id="tc1",
             name="case_tc1",
             inputs=input1_dict,
@@ -123,7 +124,7 @@ def sync_data_provider_testcase() -> Sequence[SimpleTestCase]:
             createdAt=DUMMY_CREATED_AT,
             updatedAt=DUMMY_UPDATED_AT,
         ),
-        SimpleTestCase(
+        GentraceTestCase(
             id="tc2",
             name="case_tc2",
             inputs=input2_dict,
@@ -135,11 +136,11 @@ def sync_data_provider_testcase() -> Sequence[SimpleTestCase]:
     ]
 
 
-def sync_data_provider_mixed() -> Sequence[Union[SimpleTestCase, SimpleTestInputDict]]:
+def sync_data_provider_mixed() -> Sequence[Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]]:
     input1_dict = model_to_dict(InputModel(a="tc_hello", b=100))
     input4_dict = model_to_dict(InputModel(a="tc_noname", b=4))
     return [
-        SimpleTestCase(
+        GentraceTestCase(
             id="tc1",
             name="case_tc1",
             inputs=input1_dict,
@@ -148,9 +149,9 @@ def sync_data_provider_mixed() -> Sequence[Union[SimpleTestCase, SimpleTestInput
             createdAt=DUMMY_CREATED_AT,
             updatedAt=DUMMY_UPDATED_AT,
         ),
-        SimpleTestInputDict(name="dict_case2", inputs={"a": "dict_world", "b": 2}),
-        SimpleTestInputDict(inputs={"a": "nameless_dict", "b": 3}),
-        SimpleTestCase(
+        GentraceTestInput(name="dict_case2", inputs={"a": "dict_world", "b": 2}),
+        GentraceTestInput(inputs={"a": "nameless_dict", "b": 3}),
+        GentraceTestCase(
             id="tc4_noid",
             name="tc4_noname_case",
             inputs=input4_dict,
@@ -162,11 +163,11 @@ def sync_data_provider_mixed() -> Sequence[Union[SimpleTestCase, SimpleTestInput
     ]
 
 
-def sync_data_provider_invalid_for_schema() -> Sequence[SimpleTestInputDict]:
+def sync_data_provider_invalid_for_schema() -> Sequence[GentraceTestInput[Dict[str, Any]]]:
     return [
-        SimpleTestInputDict(name="valid_case", inputs={"a": "ok", "b": 1}),
-        SimpleTestInputDict(name="invalid_case_missing_b", inputs={"a": "bad"}),
-        SimpleTestInputDict(name="invalid_case_wrong_type", inputs={"a": "bad2", "b": "not_an_int"}),
+        GentraceTestInput(name="valid_case", inputs={"a": "ok", "b": 1}),
+        GentraceTestInput(name="invalid_case_missing_b", inputs={"a": "bad"}),
+        GentraceTestInput(name="invalid_case_wrong_type", inputs={"a": "bad2", "b": "not_an_int"}),
     ]
 
 
@@ -188,7 +189,7 @@ async def test_eval_dataset_outside_experiment() -> None:
 @pytest.mark.asyncio
 async def test_eval_dataset_sync_interaction_sync_data() -> None:
     """Test eval_dataset with sync interaction and sync data provider (dicts)."""
-    results = await eval_dataset(
+    results = await eval_dataset(  # type: ignore
         data=sync_data_provider_dict,
         interaction=sync_interaction,
     )
@@ -305,8 +306,8 @@ async def test_eval_dataset_with_schema_failure(caplog: LogCaptureFixture) -> No
 async def test_eval_dataset_with_plain_array_dict() -> None:
     """Test eval_dataset with a plain array of dictionaries."""
     plain_array = [
-        SimpleTestInputDict(name="plain1", inputs={"a": "plain_hello", "b": 1}),
-        SimpleTestInputDict(name="plain2", inputs={"a": "plain_world", "b": 2}),
+        GentraceTestInput(name="plain1", inputs={"a": "plain_hello", "b": 1}),
+        GentraceTestInput(name="plain2", inputs={"a": "plain_world", "b": 2}),
     ]
     
     results = await eval_dataset(
@@ -326,7 +327,7 @@ async def test_eval_dataset_with_plain_array_testcase() -> None:
     input2_dict = model_to_dict(InputModel(a="array_world", b=20))
     
     plain_array = [
-        SimpleTestCase(
+        GentraceTestCase(
             id="array1",
             name="array_case1",
             inputs=input1_dict,
@@ -335,7 +336,7 @@ async def test_eval_dataset_with_plain_array_testcase() -> None:
             createdAt=DUMMY_CREATED_AT,
             updatedAt=DUMMY_UPDATED_AT,
         ),
-        SimpleTestCase(
+        GentraceTestCase(
             id="array2",
             name="array_case2",
             inputs=input2_dict,
@@ -362,7 +363,7 @@ async def test_eval_dataset_with_plain_array_mixed() -> None:
     input1_dict = model_to_dict(InputModel(a="mixed_tc", b=5))
     
     plain_array = [
-        SimpleTestCase(
+        GentraceTestCase(
             id="mixed1",
             name="mixed_testcase",
             inputs=input1_dict,
@@ -371,7 +372,7 @@ async def test_eval_dataset_with_plain_array_mixed() -> None:
             createdAt=DUMMY_CREATED_AT,
             updatedAt=DUMMY_UPDATED_AT,
         ),
-        SimpleTestInputDict(name="mixed_dict", inputs={"a": "mixed_dict_data", "b": 15}),
+        GentraceTestInput(name="mixed_dict", inputs={"a": "mixed_dict_data", "b": 15}),
     ]
     
     results = await eval_dataset(
@@ -388,8 +389,8 @@ async def test_eval_dataset_with_plain_array_mixed() -> None:
 async def test_eval_dataset_with_plain_array_and_schema() -> None:
     """Test eval_dataset with a plain array and Pydantic schema validation."""
     plain_array = [
-        SimpleTestInputDict(name="schema1", inputs={"a": "validated", "b": 42}),
-        SimpleTestInputDict(name="schema2", inputs={"a": "also_validated", "b": 84}),
+        GentraceTestInput(name="schema1", inputs={"a": "validated", "b": 42}),
+        GentraceTestInput(name="schema2", inputs={"a": "also_validated", "b": 84}),
     ]
     
     results = await eval_dataset(

--- a/tests/lib/test_eval_dataset_concurrency.py
+++ b/tests/lib/test_eval_dataset_concurrency.py
@@ -4,7 +4,7 @@
 import time
 import asyncio
 import threading
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
 from unittest.mock import MagicMock
 
 import pytest
@@ -97,7 +97,7 @@ def init_gentrace():
     init(api_key="test-key", base_url="https://gentrace.ai/api")
 
 
-def create_test_data(num_items: int) -> List[GentraceTestInput[Any]]:
+def create_test_data(num_items: int) -> List[GentraceTestInput[Mapping[str, Any]]]:
     """Create test data."""
     return [
         GentraceTestInput(inputs={"id": f"test-{i}"})

--- a/tests/lib/test_eval_dataset_concurrency.py
+++ b/tests/lib/test_eval_dataset_concurrency.py
@@ -1,9 +1,10 @@
+# pyright: reportUnknownVariableType=false, reportUnknownArgumentType=false, reportArgumentType=false, reportCallIssue=false, reportTypedDictNotRequiredAccess=false
 """Tests for eval_dataset concurrency control."""
 
 import time
 import asyncio
 import threading
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,6 +13,7 @@ import gentrace.lib.experiment as exp_mod
 import gentrace.lib.experiment_control as exp_ctrl
 from gentrace import TestInput as GentraceTestInput, init, experiment, eval_dataset
 from gentrace.types.experiment import Experiment
+from gentrace.types import TestCase as GentraceTestCase
 
 # Use same pipeline ID as other tests
 PIPELINE_ID = "76ecc73d-3419-431f-aafc-93a9d1af1b83"
@@ -95,10 +97,10 @@ def init_gentrace():
     init(api_key="test-key", base_url="https://gentrace.ai/api")
 
 
-def create_test_data(num_items: int) -> List[GentraceTestInput[Dict[str, Any]]]:
+def create_test_data(num_items: int) -> List[Dict[str, Any]]:
     """Create test data."""
     return [
-        {"inputs": {"id": f"test-{i}"}}
+        {"inputs": {"id": f"test-{i}"}}  # type: ignore
         for i in range(num_items)
     ]
 
@@ -108,9 +110,13 @@ def create_test_data(num_items: int) -> List[GentraceTestInput[Dict[str, Any]]]:
 async def test_async_function_with_max_concurrency(tracker: ConcurrencyTracker) -> None:
     """Test that async functions respect max_concurrency using semaphore."""
     
-    async def async_task(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    async def async_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
         """Async task that tracks concurrency."""
-        task_id = inputs.get("id", "unknown")
+        if isinstance(test_case, GentraceTestCase):
+            inputs = test_case.inputs
+        else:
+            inputs = test_case['inputs']  # type: ignore
+        task_id = str(inputs.get("id", "unknown"))
         current = await tracker.increment(task_id)
         
         # Simulate async work
@@ -137,9 +143,13 @@ async def test_sync_function_with_max_concurrency(tracker: ConcurrencyTracker) -
     # Use a thread-safe counter for sync functions
     sync_lock = threading.Lock()
     
-    def sync_task(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def sync_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
         """Sync task that tracks concurrency."""
-        task_id = inputs.get("id", "unknown")
+        if isinstance(test_case, GentraceTestCase):
+            inputs = test_case.inputs
+        else:
+            inputs = test_case['inputs']  # type: ignore
+        task_id = str(inputs.get("id", "unknown"))
         
         # Manually track concurrency for sync functions
         with sync_lock:
@@ -170,9 +180,13 @@ async def test_sync_function_with_max_concurrency(tracker: ConcurrencyTracker) -
 async def test_no_max_concurrency(tracker: ConcurrencyTracker) -> None:
     """Test that without max_concurrency, all tasks run concurrently."""
     
-    async def async_task(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    async def async_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
         """Async task that tracks concurrency."""
-        task_id = inputs.get("id", "unknown")
+        if isinstance(test_case, GentraceTestCase):
+            inputs = test_case.inputs
+        else:
+            inputs = test_case['inputs']  # type: ignore
+        task_id = str(inputs.get("id", "unknown"))
         current = await tracker.increment(task_id)
         
         # Simulate async work
@@ -199,9 +213,13 @@ async def test_max_concurrency_zero() -> None:
     
     tracker = ConcurrencyTracker()
     
-    async def async_task(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    async def async_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
         """Async task that tracks concurrency."""
-        task_id = inputs.get("id", "unknown")
+        if isinstance(test_case, GentraceTestCase):
+            inputs = test_case.inputs
+        else:
+            inputs = test_case['inputs']  # type: ignore
+        task_id = str(inputs.get("id", "unknown"))
         current = await tracker.increment(task_id)
         
         # Simulate async work
@@ -228,9 +246,13 @@ async def test_max_concurrency_one() -> None:
     
     tracker = ConcurrencyTracker()
     
-    async def async_task(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    async def async_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
         """Async task that tracks concurrency."""
-        task_id = inputs.get("id", "unknown")
+        if isinstance(test_case, GentraceTestCase):
+            inputs = test_case.inputs
+        else:
+            inputs = test_case['inputs']  # type: ignore
+        task_id = str(inputs.get("id", "unknown"))
         current = await tracker.increment(task_id)
         
         # Simulate async work
@@ -255,7 +277,7 @@ async def test_max_concurrency_one() -> None:
 async def test_max_concurrency_exceeds_limit() -> None:
     """Test that max_concurrency > 30 raises ValueError."""
     
-    async def async_task(_: Dict[str, Any]) -> Dict[str, Any]:
+    async def async_task(_: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
         """Simple async task."""
         return {"result": "ok"}
     

--- a/tests/lib/test_eval_dataset_concurrency.py
+++ b/tests/lib/test_eval_dataset_concurrency.py
@@ -11,8 +11,7 @@ import pytest
 
 import gentrace.lib.experiment as exp_mod
 import gentrace.lib.experiment_control as exp_ctrl
-from gentrace import init, experiment, eval_dataset
-from gentrace import TestInput as GentraceTestInput
+from gentrace import TestInput as GentraceTestInput, init, experiment, eval_dataset
 from gentrace.types import TestCase as GentraceTestCase
 from gentrace.types.experiment import Experiment
 

--- a/tests/lib/test_eval_dataset_concurrency.py
+++ b/tests/lib/test_eval_dataset_concurrency.py
@@ -4,14 +4,15 @@
 import time
 import asyncio
 import threading
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 from unittest.mock import MagicMock
 
 import pytest
 
 import gentrace.lib.experiment as exp_mod
 import gentrace.lib.experiment_control as exp_ctrl
-from gentrace import TestInput as GentraceTestInput, init, experiment, eval_dataset
+from gentrace import init, experiment, eval_dataset
+from gentrace import TestInput as GentraceTestInput
 from gentrace.types import TestCase as GentraceTestCase
 from gentrace.types.experiment import Experiment
 
@@ -97,10 +98,10 @@ def init_gentrace():
     init(api_key="test-key", base_url="https://gentrace.ai/api")
 
 
-def create_test_data(num_items: int) -> List[Dict[str, Any]]:
+def create_test_data(num_items: int) -> List[GentraceTestInput]:
     """Create test data."""
     return [
-        {"inputs": {"id": f"test-{i}"}}  # type: ignore
+        GentraceTestInput(inputs={"id": f"test-{i}"})
         for i in range(num_items)
     ]
 
@@ -110,12 +111,9 @@ def create_test_data(num_items: int) -> List[Dict[str, Any]]:
 async def test_async_function_with_max_concurrency(tracker: ConcurrencyTracker) -> None:
     """Test that async functions respect max_concurrency using semaphore."""
     
-    async def async_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+    async def async_task(test_case: GentraceTestCase) -> Dict[str, Any]:
         """Async task that tracks concurrency."""
-        if isinstance(test_case, GentraceTestCase):
-            inputs = test_case.inputs
-        else:
-            inputs = test_case['inputs']  # type: ignore
+        inputs = test_case.inputs
         task_id = str(inputs.get("id", "unknown"))
         current = await tracker.increment(task_id)
         
@@ -143,12 +141,9 @@ async def test_sync_function_with_max_concurrency(tracker: ConcurrencyTracker) -
     # Use a thread-safe counter for sync functions
     sync_lock = threading.Lock()
     
-    def sync_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+    def sync_task(test_case: GentraceTestCase) -> Dict[str, Any]:
         """Sync task that tracks concurrency."""
-        if isinstance(test_case, GentraceTestCase):
-            inputs = test_case.inputs
-        else:
-            inputs = test_case['inputs']  # type: ignore
+        inputs = test_case.inputs
         task_id = str(inputs.get("id", "unknown"))
         
         # Manually track concurrency for sync functions
@@ -180,12 +175,9 @@ async def test_sync_function_with_max_concurrency(tracker: ConcurrencyTracker) -
 async def test_no_max_concurrency(tracker: ConcurrencyTracker) -> None:
     """Test that without max_concurrency, all tasks run concurrently."""
     
-    async def async_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+    async def async_task(test_case: GentraceTestCase) -> Dict[str, Any]:
         """Async task that tracks concurrency."""
-        if isinstance(test_case, GentraceTestCase):
-            inputs = test_case.inputs
-        else:
-            inputs = test_case['inputs']  # type: ignore
+        inputs = test_case.inputs
         task_id = str(inputs.get("id", "unknown"))
         current = await tracker.increment(task_id)
         
@@ -213,12 +205,9 @@ async def test_max_concurrency_zero() -> None:
     
     tracker = ConcurrencyTracker()
     
-    async def async_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+    async def async_task(test_case: GentraceTestCase) -> Dict[str, Any]:
         """Async task that tracks concurrency."""
-        if isinstance(test_case, GentraceTestCase):
-            inputs = test_case.inputs
-        else:
-            inputs = test_case['inputs']  # type: ignore
+        inputs = test_case.inputs
         task_id = str(inputs.get("id", "unknown"))
         current = await tracker.increment(task_id)
         
@@ -246,12 +235,9 @@ async def test_max_concurrency_one() -> None:
     
     tracker = ConcurrencyTracker()
     
-    async def async_task(test_case: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+    async def async_task(test_case: GentraceTestCase) -> Dict[str, Any]:
         """Async task that tracks concurrency."""
-        if isinstance(test_case, GentraceTestCase):
-            inputs = test_case.inputs
-        else:
-            inputs = test_case['inputs']  # type: ignore
+        inputs = test_case.inputs
         task_id = str(inputs.get("id", "unknown"))
         current = await tracker.increment(task_id)
         
@@ -277,7 +263,7 @@ async def test_max_concurrency_one() -> None:
 async def test_max_concurrency_exceeds_limit() -> None:
     """Test that max_concurrency > 30 raises ValueError."""
     
-    async def async_task(_: Union[GentraceTestCase, GentraceTestInput[Dict[str, Any]]]) -> Dict[str, Any]:
+    async def async_task(_: GentraceTestCase) -> Dict[str, Any]:
         """Simple async task."""
         return {"result": "ok"}
     

--- a/tests/lib/test_eval_dataset_concurrency.py
+++ b/tests/lib/test_eval_dataset_concurrency.py
@@ -97,7 +97,7 @@ def init_gentrace():
     init(api_key="test-key", base_url="https://gentrace.ai/api")
 
 
-def create_test_data(num_items: int) -> List[GentraceTestInput]:
+def create_test_data(num_items: int) -> List[GentraceTestInput[Any]]:
     """Create test data."""
     return [
         GentraceTestInput(inputs={"id": f"test-{i}"})

--- a/tests/lib/test_eval_dataset_concurrency.py
+++ b/tests/lib/test_eval_dataset_concurrency.py
@@ -12,8 +12,8 @@ import pytest
 import gentrace.lib.experiment as exp_mod
 import gentrace.lib.experiment_control as exp_ctrl
 from gentrace import TestInput as GentraceTestInput, init, experiment, eval_dataset
-from gentrace.types.experiment import Experiment
 from gentrace.types import TestCase as GentraceTestCase
+from gentrace.types.experiment import Experiment
 
 # Use same pipeline ID as other tests
 PIPELINE_ID = "76ecc73d-3419-431f-aafc-93a9d1af1b83"


### PR DESCRIPTION
https://github.com/gentrace/gentrace-python/blob/057bae99460efa8e66b768bf5902a5ce59724e31/examples/eval_dataset_local_cases.py#L32

https://github.com/gentrace/gentrace-python/blob/057bae99460efa8e66b768bf5902a5ce59724e31/examples/eval_dataset_simple.py#L26

Look at these two scripts to learn about the interface structure.

The main idea is that both local test cases (defined with `TestInput`) and remote test cases are represented with the same `TestCase`, Stainless-generated class in the `interaction()` function now. This makes the typing much more straightforward rather than creating a messy `Union[TestInput, TestCase]` structure.

Also I changed TestInput to be a Pydantic class rather than TypedDict.