### PR TITLE
feat(otlp): show partial success issues directly in the client SDK code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.importFormat": "relative",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ testpaths = ["tests"]
 addopts = "--tb=short"
 xfail_strict = true
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
+asyncio_default_fixture_loop_scope = "session"
 filterwarnings = [
   "error",
   "ignore::ResourceWarning",

--- a/src/gentrace/__init__.py
+++ b/src/gentrace/__init__.py
@@ -112,9 +112,11 @@ from .lib.constants import (
     ATTR_GENTRACE_FN_OUTPUT_EVENT_NAME,
 )
 from .lib.experiment import experiment
+from .lib.otel_setup import setup
 from .lib.interaction import interaction
 from .lib.eval_dataset import TestInput, eval_dataset
 from .lib.span_processor import GentraceSpanProcessor
+from .lib.custom_otlp_exporter import GentraceOTLPSpanExporter
 
 ### End custom Gentrace imports
 
@@ -161,6 +163,7 @@ __all__ = [
 
     # Start custom Gentrace exports
     "init",
+    "setup",
     "traced",
     "interaction",
     "experiment",
@@ -176,6 +179,7 @@ __all__ = [
     "ATTR_GENTRACE_SAMPLE_KEY",
     "GentraceSampler",
     "GentraceSpanProcessor",
+    "GentraceOTLPSpanExporter",
     "TestCase",
     "Experiment",
     "Dataset",

--- a/src/gentrace/lib/custom_otlp_exporter.py
+++ b/src/gentrace/lib/custom_otlp_exporter.py
@@ -1,0 +1,167 @@
+import logging
+from typing import TYPE_CHECKING, Dict, Union, Iterator, Optional
+from itertools import count
+from typing_extensions import Literal, override
+
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceResponse,
+)
+
+from .utils import display_gentrace_warning
+from .warnings import GentraceWarnings
+
+if TYPE_CHECKING:
+    import requests
+
+_logger = logging.getLogger(__name__)
+
+
+def _create_exp_backoff_generator(max_value: int = 0) -> Iterator[int]:
+    """
+    Creates an exponential backoff generator matching OpenTelemetry's implementation.
+    
+    This is reimplemented here to avoid importing from private modules.
+    """
+    for i in count(0):
+        out = 2**i
+        yield min(out, max_value) if max_value else out
+
+
+class GentraceOTLPSpanExporter(OTLPSpanExporter):
+    """
+    Custom OTLP Span Exporter that extends the default OTLPSpanExporter
+    to handle partial success responses from the OTLP endpoint.
+
+    This exporter parses the response body even for successful (200 OK) responses
+    and logs warnings when spans are partially rejected or when the server
+    sends warning messages.
+    """
+
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        certificate_file: Optional[str] = None,
+        client_key_file: Optional[str] = None,
+        client_certificate_file: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[int] = None,
+        compression: Optional[Compression] = None,
+        session: Optional["requests.Session"] = None,
+    ):
+        """Initialize the custom exporter with the same parameters as the base class."""
+        super().__init__(
+            endpoint=endpoint,
+            certificate_file=certificate_file,
+            client_key_file=client_key_file,
+            client_certificate_file=client_certificate_file,
+            headers=headers,
+            timeout=timeout,
+            compression=compression,
+            session=session,
+        )
+
+    @override
+    def _export_serialized_spans(
+        self, serialized_data: bytes
+    ) -> Union[Literal[SpanExportResult.FAILURE], Literal[SpanExportResult.SUCCESS]]:
+        """
+        Override to add partial success checking while keeping parent's retry logic.
+        
+        This is a minimal override that adds our custom logic only when needed.
+        """
+        # Use the parent's retry logic directly
+        for delay in _create_exp_backoff_generator(
+            max_value=self._MAX_RETRY_TIMEOUT
+        ):
+            if delay == self._MAX_RETRY_TIMEOUT:
+                return SpanExportResult.FAILURE
+
+            resp = self._export(serialized_data)
+            
+            if resp.ok:
+                # Add our partial success check here
+                if resp.content:
+                    self._check_partial_success(resp)
+                return SpanExportResult.SUCCESS
+            elif self._retryable(resp):
+                _logger.warning(
+                    "Transient error %s encountered while exporting span batch, retrying in %ss.",
+                    resp.reason,
+                    delay,
+                )
+                from time import sleep
+                sleep(delay)
+                continue
+            else:
+                _logger.error(
+                    "Failed to export batch code: %s, reason: %s",
+                    resp.status_code,
+                    resp.text,
+                )
+                return SpanExportResult.FAILURE
+        
+        return SpanExportResult.FAILURE
+
+    def _check_partial_success(self, resp: "requests.Response") -> None:
+        """
+        Check response for partial success indicators and display warnings.
+        
+        This method is isolated from the main export logic to minimize
+        differences from the parent class.
+        """
+        try:
+            # Check response content type
+            content_type = resp.headers.get('content-type', '').lower()
+            
+            response_proto = None
+            
+            if 'application/json' in content_type:
+                # Handle JSON response
+                import json
+                json_data = json.loads(resp.content.decode('utf-8'))
+                
+                # Check if this is a byte array encoded as JSON object with numeric keys
+                if all(isinstance(k, str) and k.isdigit() for k in json_data.keys()):
+                    # Convert JSON object with numeric keys to bytes
+                    byte_array = bytes([json_data[str(i)] for i in range(len(json_data))])
+                    
+                    # Try to parse as protobuf
+                    response_proto = ExportTraceServiceResponse()
+                    response_proto.ParseFromString(byte_array)
+                else:
+                    # Normal JSON response
+                    # Convert JSON to protobuf message
+                    response_proto = ExportTraceServiceResponse()
+                    if 'partialSuccess' in json_data:
+                        partial_success_json = json_data['partialSuccess']
+                        if 'rejectedSpans' in partial_success_json:
+                            response_proto.partial_success.rejected_spans = int(partial_success_json['rejectedSpans'])
+                        if 'errorMessage' in partial_success_json:
+                            response_proto.partial_success.error_message = partial_success_json['errorMessage']
+            else:
+                # Handle protobuf response
+                response_proto = ExportTraceServiceResponse()
+                response_proto.ParseFromString(resp.content)
+
+            # Check if partial_success field is present
+            if response_proto and response_proto.HasField("partial_success"):
+                partial_success = response_proto.partial_success
+
+                # Check for rejected spans
+                if partial_success.rejected_spans > 0 or partial_success.error_message:
+                    # Display the warning using the Gentrace warning system
+                    warning = GentraceWarnings.OtelPartialFailureWarning(
+                        partial_success.rejected_spans,
+                        partial_success.error_message
+                    )
+                    display_gentrace_warning(warning)
+        except Exception as e:
+            # Don't fail the export if we can't parse the response
+            # This ensures backward compatibility
+            _logger.debug(
+                "Failed to parse OTLP response for partial success: %s",
+                str(e),
+            )

--- a/src/gentrace/lib/otel_setup.py
+++ b/src/gentrace/lib/otel_setup.py
@@ -14,12 +14,12 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 from opentelemetry.sdk.trace.sampling import Sampler
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
 from .utils import get_console, display_gentrace_warning
 from .warnings import GentraceWarnings
 from .span_processor import GentraceSpanProcessor
 from .client_instance import _get_sync_client_instance
+from .custom_otlp_exporter import GentraceOTLPSpanExporter
 
 
 def _display_init_error() -> None:
@@ -273,8 +273,8 @@ def setup(
             "Please set the GENTRACE_API_KEY environment variable or call init() with an API key."
         )
 
-    # Create OTLP exporter
-    otlp_exporter = OTLPSpanExporter(
+    # Create custom OTLP exporter with partial success handling
+    otlp_exporter = GentraceOTLPSpanExporter(
         endpoint=final_trace_endpoint,
         headers=exporter_headers,
     )

--- a/src/gentrace/lib/utils.py
+++ b/src/gentrace/lib/utils.py
@@ -527,7 +527,7 @@ def _show_otel_warning() -> None:
         except Exception:  # Fallback if rich formatting/printing fails
             fallback_message = """Gentrace: OpenTelemetry SDK does not appear to be configured. This means that Gentrace features like @interaction, @eval, @traced, and eval_dataset() will not record any data to the Gentrace UI.
 
-Learn more: https://next.gentrace.ai/docs/sdk-reference/errors#gt-otelnotconfigurederror
+Learn more: https://gentrace.ai/docs/reference/sdk-errors#gt-otelnotconfigurederror
 
 You have two options:
 

--- a/tests/lib/test_custom_otlp_exporter.py
+++ b/tests/lib/test_custom_otlp_exporter.py
@@ -1,0 +1,178 @@
+import logging
+from typing import List
+from unittest.mock import Mock, patch
+
+import pytest
+from pytest import LogCaptureFixture
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTracePartialSuccess,
+    ExportTraceServiceResponse,
+)
+
+from gentrace.lib.custom_otlp_exporter import GentraceOTLPSpanExporter
+
+
+@pytest.fixture
+def mock_spans() -> List[Mock]:
+    """Create mock spans for testing."""
+    span = Mock()
+    span.name = "test_span"
+    return [span]
+
+
+@pytest.fixture
+def exporter() -> GentraceOTLPSpanExporter:
+    """Create an exporter instance for testing."""
+    return GentraceOTLPSpanExporter(
+        endpoint="http://localhost:4318/v1/traces",
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+
+class TestCustomOTLPExporter:
+    """Test cases for the custom OTLP exporter with partial success handling."""
+
+    def test_successful_export_without_partial_success(
+        self, exporter: GentraceOTLPSpanExporter, mock_spans: List[Mock], caplog: LogCaptureFixture
+    ) -> None:
+        """Test successful export without partial success response."""
+        # Mock response without body
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.content = b""  # Empty content
+        mock_response.headers = {"content-type": "application/x-protobuf"}
+
+        with patch.object(exporter, "_serialize_spans", return_value=b"serialized"):
+            with patch.object(exporter, "_export", return_value=mock_response):
+                result = exporter.export(mock_spans)
+
+        assert result == SpanExportResult.SUCCESS
+        # No warnings should be logged
+        assert "partial success" not in caplog.text.lower()
+
+    def test_export_with_rejected_spans(
+        self, exporter: GentraceOTLPSpanExporter, mock_spans: List[Mock]
+    ) -> None:
+        """Test export with partial success - some spans rejected."""
+        # Create partial success response
+        partial_success = ExportTracePartialSuccess()
+        partial_success.rejected_spans = 5
+        partial_success.error_message = "Some spans were invalid"
+
+        response_proto = ExportTraceServiceResponse()
+        response_proto.partial_success.CopyFrom(partial_success)
+
+        # Mock response with partial success
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.content = response_proto.SerializeToString()
+        mock_response.headers = {"content-type": "application/x-protobuf"}
+
+        with patch.object(exporter, "_serialize_spans", return_value=b"serialized"):
+            with patch.object(exporter, "_export", return_value=mock_response):
+                with patch("gentrace.lib.custom_otlp_exporter.display_gentrace_warning") as mock_display_warning:
+                    result = exporter.export(mock_spans)
+
+        assert result == SpanExportResult.SUCCESS
+        # Check that warning was displayed
+        mock_display_warning.assert_called_once()
+        warning = mock_display_warning.call_args[0][0]
+        assert warning.warning_id == "GT_OtelPartialFailureWarning"
+        assert "5" in warning.get_simple_message()
+        assert "Some spans were invalid" in warning.get_simple_message()
+
+    def test_export_with_warning_message_only(
+        self, exporter: GentraceOTLPSpanExporter, mock_spans: List[Mock]
+    ) -> None:
+        """Test export with warning message but no rejected spans."""
+        # Create partial success response with warning only
+        partial_success = ExportTracePartialSuccess()
+        partial_success.rejected_spans = 0
+        partial_success.error_message = "Consider using batch export for better performance"
+
+        response_proto = ExportTraceServiceResponse()
+        response_proto.partial_success.CopyFrom(partial_success)
+
+        # Mock response
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.content = response_proto.SerializeToString()
+        mock_response.headers = {"content-type": "application/x-protobuf"}
+
+        with patch.object(exporter, "_serialize_spans", return_value=b"serialized"):
+            with patch.object(exporter, "_export", return_value=mock_response):
+                with patch("gentrace.lib.custom_otlp_exporter.display_gentrace_warning") as mock_display_warning:
+                    result = exporter.export(mock_spans)
+
+        assert result == SpanExportResult.SUCCESS
+        # Check that warning was displayed
+        mock_display_warning.assert_called_once()
+        warning = mock_display_warning.call_args[0][0]
+        assert warning.warning_id == "GT_OtelPartialFailureWarning"
+        assert "Consider using batch export for better performance" in warning.get_simple_message()
+
+    def test_export_with_parse_error(
+        self, exporter: GentraceOTLPSpanExporter, mock_spans: List[Mock], caplog: LogCaptureFixture
+    ) -> None:
+        """Test that parse errors don't break the export."""
+        # Mock response with invalid protobuf data
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.content = b"invalid protobuf data"
+        mock_response.headers = {"content-type": "application/x-protobuf"}
+
+        with patch.object(exporter, "_serialize_spans", return_value=b"serialized"):
+            with patch.object(exporter, "_export", return_value=mock_response):
+                with caplog.at_level(logging.DEBUG):
+                    result = exporter.export(mock_spans)
+
+        assert result == SpanExportResult.SUCCESS
+        # Check that debug message was logged but export still succeeded
+        assert "Failed to parse OTLP response for partial success" in caplog.text
+
+    def test_export_failure(
+        self, exporter: GentraceOTLPSpanExporter, mock_spans: List[Mock], caplog: LogCaptureFixture
+    ) -> None:
+        """Test export failure scenario."""
+        # Mock failed response
+        mock_response = Mock()
+        mock_response.ok = False
+        mock_response.status_code = 400
+        mock_response.text = "Bad request"
+        mock_response.reason = "Bad Request"
+
+        with patch.object(exporter, "_serialize_spans", return_value=b"serialized"):
+            with patch.object(exporter, "_export", return_value=mock_response):
+                with patch.object(exporter, "_retryable", return_value=False):
+                    with caplog.at_level(logging.ERROR):
+                        result = exporter.export(mock_spans)
+
+        assert result == SpanExportResult.FAILURE
+        assert "Failed to export batch code: 400" in caplog.text
+
+    def test_retry_behavior(
+        self, exporter: GentraceOTLPSpanExporter, mock_spans: List[Mock], caplog: LogCaptureFixture
+    ) -> None:
+        """Test retry behavior for transient errors."""
+        # Mock responses - first fails with retryable error, then succeeds
+        mock_response_fail = Mock()
+        mock_response_fail.ok = False
+        mock_response_fail.status_code = 503
+        mock_response_fail.reason = "Service Unavailable"
+
+        mock_response_success = Mock()
+        mock_response_success.ok = True
+        mock_response_success.content = b""
+
+        responses = [mock_response_fail, mock_response_success]
+
+        with patch.object(exporter, "_serialize_spans", return_value=b"serialized"):
+            with patch.object(exporter, "_export", side_effect=responses):
+                with patch.object(exporter, "_retryable", side_effect=[True, False]):
+                    with patch("time.sleep"):  # Mock sleep to speed up test
+                        with caplog.at_level(logging.WARNING):
+                            result = exporter.export(mock_spans)
+
+        assert result == SpanExportResult.SUCCESS
+        assert "Transient error Service Unavailable encountered" in caplog.text


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/pull/3637

Unfortunately the default OtlpSpanProcessor doesn't show errors for partial successes from the remote OTEL backend. I created an inherited version of this processor which does this and shows the standard boxed warning in this case.

Make the below patch in the Gentrace server to test the behavior.

```

diff --git a/app/src/server/otel/bufferedInsertGTSpans.ts b/app/src/server/otel/bufferedInsertGTSpans.ts
index 2b3940380..136baecab 100644
--- a/app/src/server/otel/bufferedInsertGTSpans.ts
+++ b/app/src/server/otel/bufferedInsertGTSpans.ts
@@ -57,7 +57,7 @@ export const bufferedInsertGTSpans = async (
   );
   const [badSpansHasPipelineAndExperiment, survivingSpans0] = split(
     gtSpans,
-    (s) => !!s.pipelineId && !!s.experimentId,
+    (s) => !(!!s.pipelineId && !!s.experimentId),
   );

   const traceIds = new Set(survivingSpans0.map((gtSpan) => gtSpan.traceId));
```