### PR TITLE
fix: add gentrace.in_experiment to span attributes

### DIFF
--- a/src/gentrace/__init__.py
+++ b/src/gentrace/__init__.py
@@ -107,6 +107,7 @@ from .lib.constants import (
     ATTR_GENTRACE_PIPELINE_ID,
     ATTR_GENTRACE_TEST_CASE_ID,
     ATTR_GENTRACE_EXPERIMENT_ID,
+    ATTR_GENTRACE_IN_EXPERIMENT,
     ATTR_GENTRACE_TEST_CASE_NAME,
     ATTR_GENTRACE_FN_ARGS_EVENT_NAME,
     ATTR_GENTRACE_FN_OUTPUT_EVENT_NAME,
@@ -160,7 +161,6 @@ __all__ = [
     "DefaultHttpxClient",
     "DefaultAsyncHttpxClient",
     "DefaultAioHttpClient",
-
     # Start custom Gentrace exports
     "init",
     "setup",
@@ -170,6 +170,8 @@ __all__ = [
     "eval",
     "eval_dataset",
     "TestInput",
+    "ATTR_GENTRACE_SAMPLE_KEY",
+    "ATTR_GENTRACE_IN_EXPERIMENT",
     "ATTR_GENTRACE_PIPELINE_ID",
     "ATTR_GENTRACE_TEST_CASE_ID",
     "ATTR_GENTRACE_EXPERIMENT_ID",

--- a/src/gentrace/lib/constants.py
+++ b/src/gentrace/lib/constants.py
@@ -12,6 +12,7 @@ ATTR_GENTRACE_TEST_CASE_NAME = "gentrace.test_case_name"
 ATTR_GENTRACE_TEST_CASE_ID = "gentrace.test_case_id"
 
 ATTR_GENTRACE_SAMPLE_KEY = "gentrace.sample"
+ATTR_GENTRACE_IN_EXPERIMENT = "gentrace.in_experiment"
 
 # Maximum allowed concurrency for eval_dataset
 MAX_EVAL_DATASET_CONCURRENCY = 100
@@ -25,5 +26,6 @@ __all__ = [
     "ATTR_GENTRACE_TEST_CASE_ID",
     "ATTR_GENTRACE_PIPELINE_ID",
     "ATTR_GENTRACE_SAMPLE_KEY",
+    "ATTR_GENTRACE_IN_EXPERIMENT",
     "MAX_EVAL_DATASET_CONCURRENCY",
 ]

--- a/src/gentrace/lib/eval.py
+++ b/src/gentrace/lib/eval.py
@@ -92,7 +92,7 @@ def eval(
                 ATTR_GENTRACE_SAMPLE_KEY, "true", context=current_context
             )
             context_with_modified_baggage = otel_baggage.set_baggage(
-                ATTR_GENTRACE_IN_EXPERIMENT, "true", context=current_context
+                ATTR_GENTRACE_IN_EXPERIMENT, "true", context=context_with_modified_baggage
             )
 
             token = otel_context.attach(context_with_modified_baggage)

--- a/src/gentrace/lib/eval.py
+++ b/src/gentrace/lib/eval.py
@@ -13,6 +13,7 @@ from .constants import (
     ANONYMOUS_SPAN_NAME,
     ATTR_GENTRACE_SAMPLE_KEY,
     ATTR_GENTRACE_EXPERIMENT_ID,
+    ATTR_GENTRACE_IN_EXPERIMENT,
     ATTR_GENTRACE_TEST_CASE_NAME,
     ATTR_GENTRACE_FN_ARGS_EVENT_NAME,
     ATTR_GENTRACE_FN_OUTPUT_EVENT_NAME,
@@ -89,6 +90,9 @@ def eval(
             current_context = otel_context.get_current()
             context_with_modified_baggage = otel_baggage.set_baggage(
                 ATTR_GENTRACE_SAMPLE_KEY, "true", context=current_context
+            )
+            context_with_modified_baggage = otel_baggage.set_baggage(
+                ATTR_GENTRACE_IN_EXPERIMENT, "true", context=current_context
             )
 
             token = otel_context.attach(context_with_modified_baggage)

--- a/src/gentrace/lib/eval_dataset.py
+++ b/src/gentrace/lib/eval_dataset.py
@@ -43,6 +43,7 @@ from .constants import (
     ATTR_GENTRACE_SAMPLE_KEY,
     ATTR_GENTRACE_TEST_CASE_ID,
     ATTR_GENTRACE_EXPERIMENT_ID,
+    ATTR_GENTRACE_IN_EXPERIMENT,
     ATTR_GENTRACE_TEST_CASE_NAME,
     MAX_EVAL_DATASET_CONCURRENCY,
     ATTR_GENTRACE_FN_ARGS_EVENT_NAME,
@@ -215,6 +216,9 @@ async def _run_single_test_case_for_dataset(
     # Set up baggage context similar to @interaction()
     current_context = otel_context.get_current()
     context_with_modified_baggage = otel_baggage.set_baggage(ATTR_GENTRACE_SAMPLE_KEY, "true", context=current_context)
+    context_with_modified_baggage = otel_baggage.set_baggage(
+        ATTR_GENTRACE_IN_EXPERIMENT, "true", context=current_context
+    )
 
     token = otel_context.attach(context_with_modified_baggage)
     try:

--- a/src/gentrace/lib/eval_dataset.py
+++ b/src/gentrace/lib/eval_dataset.py
@@ -217,7 +217,7 @@ async def _run_single_test_case_for_dataset(
     current_context = otel_context.get_current()
     context_with_modified_baggage = otel_baggage.set_baggage(ATTR_GENTRACE_SAMPLE_KEY, "true", context=current_context)
     context_with_modified_baggage = otel_baggage.set_baggage(
-        ATTR_GENTRACE_IN_EXPERIMENT, "true", context=current_context
+        ATTR_GENTRACE_IN_EXPERIMENT, "true", context=context_with_modified_baggage
     )
 
     token = otel_context.attach(context_with_modified_baggage)

--- a/src/gentrace/lib/span_processor.py
+++ b/src/gentrace/lib/span_processor.py
@@ -6,7 +6,7 @@ from opentelemetry.trace import Span
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 
-from gentrace.lib.constants import ATTR_GENTRACE_SAMPLE_KEY
+from gentrace.lib.constants import ATTR_GENTRACE_SAMPLE_KEY, ATTR_GENTRACE_IN_EXPERIMENT
 
 
 class GentraceSpanProcessor(SpanProcessor):
@@ -34,6 +34,11 @@ class GentraceSpanProcessor(SpanProcessor):
         if sample_value is not None:
             if isinstance(sample_value, str):
                 span.set_attribute(ATTR_GENTRACE_SAMPLE_KEY, sample_value)
+
+        in_experiment_value = baggage.get_baggage(ATTR_GENTRACE_IN_EXPERIMENT, context=parent_context)
+        if in_experiment_value is not None:
+            if isinstance(in_experiment_value, str):
+                span.set_attribute(ATTR_GENTRACE_IN_EXPERIMENT, in_experiment_value)
 
     @override
     def on_end(self, span: ReadableSpan) -> None:


### PR DESCRIPTION
### TL;DR

Added a new attribute `ATTR_GENTRACE_IN_EXPERIMENT` to track when spans are part of an experiment.

### What changed?

- Added a new constant `ATTR_GENTRACE_IN_EXPERIMENT` to track when spans are created within an experiment context
- Updated the span processor to propagate this attribute from baggage to spans
- Modified the eval and eval_dataset functions to set this attribute in the baggage context
- Exported the new attribute in the package's `__init__.py`

### How to test?

1. Run an experiment using `gentrace.eval()` or `gentrace.eval_dataset()`
2. Verify that spans created during the experiment have the `gentrace.in_experiment` attribute set to "true"
3. Check that this attribute is properly propagated through the OpenTelemetry context

### Why make this change?

This change enables better tracking of spans that are specifically created within experiment contexts. By adding a dedicated attribute for experiment participation, it becomes easier to filter and analyze spans that are part of experiments versus those that are not, improving observability and data analysis capabilities.