### PR TITLE
chore: clean up baggage context

### DIFF
--- a/src/gentrace/lib/eval.py
+++ b/src/gentrace/lib/eval.py
@@ -86,16 +86,11 @@ def eval(
 
             span_name = name
 
-            # Set up baggage context similar to @interaction()
-            current_context = otel_context.get_current()
-            context_with_modified_baggage = otel_baggage.set_baggage(
-                ATTR_GENTRACE_SAMPLE_KEY, "true", context=current_context
-            )
-            context_with_modified_baggage = otel_baggage.set_baggage(
-                ATTR_GENTRACE_IN_EXPERIMENT, "true", context=context_with_modified_baggage
-            )
+            context = otel_context.get_current()
+            context = otel_baggage.set_baggage(ATTR_GENTRACE_SAMPLE_KEY, "true", context=context)
+            context = otel_baggage.set_baggage(ATTR_GENTRACE_IN_EXPERIMENT, "true", context=context)
+            token = otel_context.attach(context)
 
-            token = otel_context.attach(context_with_modified_baggage)
             try:
                 with _tracer.start_as_current_span(span_name) as span:
                     span.set_attribute(ATTR_GENTRACE_EXPERIMENT_ID, experiment_context["experiment_id"])

--- a/src/gentrace/lib/eval_dataset.py
+++ b/src/gentrace/lib/eval_dataset.py
@@ -214,13 +214,11 @@ async def _run_single_test_case_for_dataset(
     result_value: Any = None  # type: ignore
 
     # Set up baggage context similar to @interaction()
-    current_context = otel_context.get_current()
-    context_with_modified_baggage = otel_baggage.set_baggage(ATTR_GENTRACE_SAMPLE_KEY, "true", context=current_context)
-    context_with_modified_baggage = otel_baggage.set_baggage(
-        ATTR_GENTRACE_IN_EXPERIMENT, "true", context=context_with_modified_baggage
-    )
+    context = otel_context.get_current()
+    context = otel_baggage.set_baggage(ATTR_GENTRACE_SAMPLE_KEY, "true", context=context)
+    context = otel_baggage.set_baggage(ATTR_GENTRACE_IN_EXPERIMENT, "true", context=context)
+    token = otel_context.attach(context)
 
-    token = otel_context.attach(context_with_modified_baggage)
     try:
         with _tracer.start_as_current_span(span_name) as span:
             span.set_attribute(ATTR_GENTRACE_EXPERIMENT_ID, experiment_context["experiment_id"])

--- a/src/gentrace/lib/span_processor.py
+++ b/src/gentrace/lib/span_processor.py
@@ -30,15 +30,10 @@ class GentraceSpanProcessor(SpanProcessor):
         Called when a Span is started, if the span.is_recording()
         returns true.
         """
-        sample_value = baggage.get_baggage(ATTR_GENTRACE_SAMPLE_KEY, context=parent_context)
-        if sample_value is not None:
-            if isinstance(sample_value, str):
-                span.set_attribute(ATTR_GENTRACE_SAMPLE_KEY, sample_value)
-
-        in_experiment_value = baggage.get_baggage(ATTR_GENTRACE_IN_EXPERIMENT, context=parent_context)
-        if in_experiment_value is not None:
-            if isinstance(in_experiment_value, str):
-                span.set_attribute(ATTR_GENTRACE_IN_EXPERIMENT, in_experiment_value)
+        for key in [ATTR_GENTRACE_SAMPLE_KEY, ATTR_GENTRACE_IN_EXPERIMENT]:
+            value = baggage.get_baggage(key, context=parent_context)
+            if isinstance(value, str):
+                span.set_attribute(key, value)
 
     @override
     def on_end(self, span: ReadableSpan) -> None:


### PR DESCRIPTION
### TL;DR

Refactored OpenTelemetry context and baggage handling for improved readability and maintainability.

### What changed?

- Simplified the OpenTelemetry context and baggage handling in `eval.py` and `eval_dataset.py` by using variable reassignment instead of creating new variables
- Refactored the attribute setting logic in `span_processor.py` to use a loop for handling multiple baggage keys, reducing code duplication

### How to test?

1. Run existing tests to ensure the OpenTelemetry context and baggage functionality still works correctly
2. Verify that spans are still properly created with the correct attributes
3. Check that experiment tracking continues to function as expected

### Why make this change?

This refactoring improves code readability and maintainability by:

- Reducing variable name complexity (using `context` instead of `context_with_modified_baggage`)
- Eliminating redundant code through variable reassignment
- Consolidating similar logic in `span_processor.py` into a loop to reduce duplication
- Making the code more concise while preserving the same functionality